### PR TITLE
ugettext -> gettext

### DIFF
--- a/bx_django_utils/models/color_field.py
+++ b/bx_django_utils/models/color_field.py
@@ -1,6 +1,6 @@
 from django.core import validators
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class HexColorValidator(validators.RegexValidator):


### PR DESCRIPTION
This is in preparation for Django 4, where the ugettext variant is being removed (now all strings are unicode in Python).
