### PR TITLE
Remove pytest warning

### DIFF
--- a/bx_django_utils_tests/tests/test_json_utils.py
+++ b/bx_django_utils_tests/tests/test_json_utils.py
@@ -7,6 +7,8 @@ from bx_django_utils.json_utils import make_json_serializable, to_json
 
 
 class TestObject:
+    __test__ = False
+
     def __init__(self, text):
         self.text = text
 


### PR DESCRIPTION
pytest freaks out
```
.:0
  :0: PytestCollectionWarning: cannot collect test class 'TestObject' because it has a __init__ constructor (from: bx_django_utils_tests/tests/test_json_utils.py)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

There are no tests in this class, mark it as such to get rid of the warning.
