### PR TITLE
+ assert_partial_query count function

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.assert_queries
 
-* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L30-L200) - Assert executed database queries: Check table names, duplicate/similar Queries.
+* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L31-L220) - Assert executed database queries: Check table names, duplicate/similar Queries.
 
 #### bx_django_utils.test_utils.datetime
 


### PR DESCRIPTION
Allow asserting query counts without specifying _all_ queries (which allows omiting irrelevant queries).
