### PR TITLE
NEW: ContentTypeCacheFixMixin for TestCases

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Utilities / helper for writing tests.
 
 * [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L30-L200) - Assert executed database queries: Check table names, duplicate/similar Queries.
 
+#### bx_django_utils.test_utils.content_types
+
+* [`ContentTypeCacheFixMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/content_types.py#L7-L35) - TestCase mixin to fill the ContentType cache to avoid flaky database queries.
+
 #### bx_django_utils.test_utils.datetime
 
 * [`MockDatetimeGenerator()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/datetime.py#L4-L50) - Mock django `timezone.now()` with generic time stamps in tests.
@@ -158,20 +162,17 @@ To start developing e.g.:
 ~$ cd bx_django_utils
 ~/bx_django_utils$ make
 help                 List all commands
-install-poetry       install or update poetry
+install-poetry       install or update poetry via pip
 install              install via poetry
 update               Update the dependencies as according to the pyproject.toml file
 lint                 Run code formatters and linter
 fix-code-style       Fix code formatting
 tox-listenvs         List all tox test environments
 tox                  Run pytest via tox with all environments
-tox-py36             Run pytest via tox with *python v3.6*
-tox-py37             Run pytest via tox with *python v3.7*
-tox-py38             Run pytest via tox with *python v3.8*
-tox-py39             Run pytest via tox with *python v3.9*
 pytest               Run pytest
 pytest-ci            Run pytest with CI settings
 publish              Release new version to PyPi
+docker-test          Run tests in docker
 makemessages         Make and compile locales message files
 start-dev-server     Start Django dev. server with the test project
 clean                Remove created files from the test project (e.g.: SQlite, static files)
@@ -190,16 +191,29 @@ If you like to start from stretch, just delete related test project files with:
 ...and start the test server again ;)
 
 
+### update this README
+
+This README will be updated via tests ;) But currently this is only done with Python 3.9 !
+If your system Python version is not 3.9: Install this Python version and switch to it, e.g.:
+
+```bash
+~/bx_django_utils$ poetry env use python3.9
+~/bx_django_utils$ make install
+~/bx_django_utils$ make pytest
+```
+
 ## License
 
 [MIT](LICENSE). Patches welcome!
+
 
 ## About us
 
 We’ve been rethinking the listening experience for kids and have created an ecosystem where haptic and listening experience are combined via smart technology - the Toniebox.
 
 We are constantly looking for engineers to join our team in different areas. If you’d be interested in contributing to our platform, have a look at: https://tonies.com/jobs/
-    
+
+
 ## Links
 
 * https://pypi.org/project/bx-django-utils/

--- a/bx_django_utils/test_utils/content_types.py
+++ b/bx_django_utils/test_utils/content_types.py
@@ -1,0 +1,35 @@
+from copy import deepcopy
+
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+
+
+class ContentTypeCacheFixMixin:
+    """
+    TestCase mixin to fill the ContentType cache to avoid flaky database queries.
+
+    The Problem is, that the ContentTypeManager used a shared cache for lookups.
+    If your tests checks the made database queries, then you may get different results
+    depending on how the cache is filled.
+
+    With this Mixin the ContentTypeManager cache is always filled and all tests will never
+    hit the databases...
+    """
+    @classmethod
+    def _fill_content_type_cache(cls):
+        # Fill ContentTypeManager cache
+        app_configs = apps.get_app_configs()
+        for app_config in app_configs:
+            models = app_config.get_models()
+            for model in models:
+                ContentType.objects.get_for_model(model)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._fill_content_type_cache()
+        cls._content_type_cache = deepcopy(ContentType.objects._cache)
+
+    def setUp(self):
+        super().setUp()
+        ContentType.objects._cache = deepcopy(self._content_type_cache)

--- a/bx_django_utils_tests/tests/test_content_types_utils.py
+++ b/bx_django_utils_tests/tests/test_content_types_utils.py
@@ -1,0 +1,34 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from bx_django_utils.test_utils.content_types import ContentTypeCacheFixMixin
+
+
+def assert_filled_content_type_cache():
+    assert ContentType.objects._cache.keys() == {'default'}
+    assert len(ContentType.objects._cache['default']) >= 20
+
+
+class ContentTypesUtilsTestCase(TestCase):
+    def test_fill_content_type_cache(self):
+        ContentType.objects._cache.clear()
+
+        assert len(ContentType.objects._cache) == 0
+
+        ContentTypeCacheFixMixin._fill_content_type_cache()
+
+        assert_filled_content_type_cache()
+
+
+class ContentTypeCacheFixMixinTestCase(ContentTypeCacheFixMixin, TestCase):
+    """
+    Test if the cache filled for all test methods via setUp()
+    """
+
+    def test_filled_cache1(self):
+        assert_filled_content_type_cache()
+        ContentType.objects._cache.clear()
+
+    def test_filled_cache2(self):
+        assert_filled_content_type_cache()
+        ContentType.objects._cache.clear()


### PR DESCRIPTION
TestCase mixin to fill the ContentType cache to avoid flaky database queries.

The Problem is, that the ContentTypeManager used a shared cache for lookups.
If your tests checks the made database queries, then you may get different results
depending on how the cache is filled.

With this Mixin the ContentTypeManager cache is always filled and all tests will never
hit the databases...