### PR TITLE
Bugfix remove_filter() for empty querysets

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Utilities to manipulate objects in database via models:
 
 #### bx_django_utils.models.queryset_utils
 
-* [`remove_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L6-L23) - Remove a applied .filter() from a QuerySet
+* [`remove_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L7-L32) - Remove a applied .filter() from a QuerySet
 
 #### bx_django_utils.models.timetracking
 

--- a/bx_django_utils/models/queryset_utils.py
+++ b/bx_django_utils/models/queryset_utils.py
@@ -1,20 +1,29 @@
 from copy import deepcopy
 
 from django.db.models import Q, QuerySet
+from django.db.models.sql.where import NothingNode
 
 
 def remove_filter(queryset: QuerySet, lookup: str) -> QuerySet:
     """
     Remove a applied .filter() from a QuerySet
     """
+    if queryset.query.is_empty():
+        # Nothing to remove if queryset is empty e.g.: ...objects.none()
+        return queryset
+
     queryset = deepcopy(queryset)  # remove the QuerySet's cache
 
     query = queryset.query
+
     clause, _ = query._add_q(Q(**{lookup: None}), query.used_aliases)
 
     def filter_lookups(node):
         if hasattr(node, 'lhs'):
             return node.lhs.target != clause.children[0].lhs.target
+
+        if isinstance(node, NothingNode):
+            return False
 
         return len(list(filter(filter_lookups, node.children))) == len(node.children)
 

--- a/bx_django_utils_tests/tests/test_model_queryset_utils.py
+++ b/bx_django_utils_tests/tests/test_model_queryset_utils.py
@@ -52,3 +52,10 @@ class QuerySetUtilsTestCase(TestCase):
         assert error_msg.startswith(
             "Cannot resolve keyword 'doesnotexists' into field. Choices are: "
         )
+
+        # Test with a "empty" queryset:
+        empty_queryset1 = User.objects.none()
+        assert empty_queryset1.count() == 0
+        empty_queryset2 = remove_filter(empty_queryset1, lookup='username')
+        assert empty_queryset2.count() == 0
+        assert empty_queryset1 is empty_queryset2  # In this case we get the same object back


### PR DESCRIPTION
Error without this PR, looks like:
```
node = <django.db.models.sql.where.NothingNode object at 0x7fe8ab53b640>

    def filter_lookups(node):
        if hasattr(node, 'lhs'):
            return node.lhs.target != clause.children[0].lhs.target

        # if isinstance(node, NothingNode):
        #     return False

>       return len(list(filter(filter_lookups, node.children))) == len(node.children)
E       AttributeError: 'NothingNode' object has no attribute 'children'

clause     = <WhereNode: (AND: <django.db.models.lookups.IsNull object at 0x7fe8ab53bd60>)>
filter_lookups = <function remove_filter.<locals>.filter_lookups at 0x7fe8ab539040>
node       = <django.db.models.sql.where.NothingNode object at 0x7fe8ab53b640>

bx_django_utils/models/queryset_utils.py:28: AttributeError
```