### PR TITLE
assert_table_counts: Add an option to exclude tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.assert_queries
 
-* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L30-L200) - Assert executed database queries: Check table names, duplicate/similar Queries.
+* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L30-L208) - Assert executed database queries: Check table names, duplicate/similar Queries.
 
 #### bx_django_utils.test_utils.datetime
 


### PR DESCRIPTION
This can be used to exclude irrelevant counts, such as permissions, ContentTypes etc. .
Also allow passing in plain dicts instead of Counters.
