### PR TITLE
Bugfix AssertQueries() if INNER JOIN with another tables ;)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.assert_queries
 
-* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L30-L208) - Assert executed database queries: Check table names, duplicate/similar Queries.
+* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L30-L209) - Assert executed database queries: Check table names, duplicate/similar Queries.
 
 #### bx_django_utils.test_utils.content_types
 

--- a/bx_django_utils/test_utils/assert_queries.py
+++ b/bx_django_utils/test_utils/assert_queries.py
@@ -62,9 +62,10 @@ class AssertQueries(SQLQueryRecorder):
                 # Skip transaction statements
                 continue
 
-            table_name = re.findall(r'(FROM|INSERT INTO|UPDATE) \"(.+?)\"', sql)
-            assert len(table_name) == 1, f'Error parsing: {sql!r}'
-            table_name = table_name[0][1]
+            table_names = re.findall(r'(FROM|INSERT INTO|UPDATE) \"(.+?)\"', sql)
+            assert len(table_names) >= 1, f'Error parsing: {sql!r}'
+            # Use only the first table name (e.g.: ignore names in inner join)
+            table_name = table_names[0][1]
             table_name_count[table_name] += 1
 
         return table_name_count

--- a/bx_django_utils_tests/tests/test_assert_queries.py
+++ b/bx_django_utils_tests/tests/test_assert_queries.py
@@ -246,3 +246,20 @@ class AssertQueriesTestCase(TestCase):
             duplicated=True,
             similar=True,
         )
+
+        # INNER JOIN tables will be ignored:
+
+        with AssertQueries() as queries:
+            Group.objects.filter(
+                permissions__in=Permission.objects.filter(content_type__app_label='not-exist')
+            ).count()
+
+        queries.assert_queries(
+            table_counts=Counter({
+                'auth_group': 1
+            }),
+            double_tables=True,
+            table_names=['auth_group'],
+            duplicated=True,
+            similar=True,
+        )


### PR DESCRIPTION
old error looks like:
```
            table_names = re.findall(r'(FROM|INSERT INTO|UPDATE) \"(.+?)\"', sql)
>           assert len(table_names) == 1, f'Error parsing: {sql!r}'
E           AssertionError: Error parsing: 'SELECT COUNT(*) AS "__count" FROM "auth_group" INNER
JOIN "auth_group_permissions" ON ("auth_group"."id" = "auth_group_permissions"."group_id") WHERE
"auth_group_permissions"."permission_id" IN (SELECT U0."id" FROM "auth_permission" U0 INNER JOIN
"django_content_type" U1 ON (U0."content_type_id" = U1."id") WHERE U1."app_label" =
\'\'\'not-exist\'\'\')'
```