### PR TITLE
+ snapshot_messages function

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.html_assertion
 
-* [`HtmlAssertionMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L29-L127) - Unittest mixin class with useful assertments around Django test client tests
+* [`HtmlAssertionMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L29-L131) - Unittest mixin class with useful assertments around Django test client tests
 * [`assert_html_response_snapshot()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L9-L26) - Assert a HttpResponse via snapshot file. (Strip all empty lines from html)
 
 #### bx_django_utils.test_utils.model_clean_assert

--- a/bx_django_utils/test_utils/html_assertion.py
+++ b/bx_django_utils/test_utils/html_assertion.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from bx_py_utils.test_utils.assertion import assert_equal
-from bx_py_utils.test_utils.snapshot import assert_text_snapshot
+from bx_py_utils.test_utils.snapshot import assert_snapshot, assert_text_snapshot
 from django.contrib.messages import get_messages
 from django.http import HttpResponse
 
@@ -38,6 +38,10 @@ class HtmlAssertionMixin:
             expected_messages,
             msg='Messages are not equal:'
         )
+
+    def snapshot_messages(self, response, **kwargs):
+        current_messages = [m.message for m in get_messages(response.wsgi_request)]
+        assert_snapshot(got=current_messages, self_file_path=Path(__file__), **kwargs)
 
     def get_msg_prefix_and_haystack(self, response, msg_prefix):
         haystack = response.content.decode('utf-8')


### PR DESCRIPTION
Add a function to not compare all Django messages statically, but snapshot them.
