### PR TITLE
+ remove_model_filter method

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Utilities to manipulate objects in database via models:
 #### bx_django_utils.models.queryset_utils
 
 * [`remove_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L7-L32) - Remove a applied .filter() from a QuerySet
+* [`remove_model_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L35-L57) - Remove a applied .filter() from a QuerySet if it contains references to the specified model
 
 #### bx_django_utils.models.timetracking
 

--- a/bx_django_utils/models/queryset_utils.py
+++ b/bx_django_utils/models/queryset_utils.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from django.db.models import Q, QuerySet
+from django.db.models import Model, Q, QuerySet
 from django.db.models.sql.where import NothingNode
 
 
@@ -21,6 +21,31 @@ def remove_filter(queryset: QuerySet, lookup: str) -> QuerySet:
     def filter_lookups(node):
         if hasattr(node, 'lhs'):
             return node.lhs.target != clause.children[0].lhs.target
+
+        if isinstance(node, NothingNode):
+            return False
+
+        return len(list(filter(filter_lookups, node.children))) == len(node.children)
+
+    query.where.children = list(filter(filter_lookups, query.where.children))
+
+    return queryset
+
+
+def remove_model_filter(queryset: QuerySet, model: Model) -> QuerySet:
+    """
+    Remove a applied .filter() from a QuerySet if it contains references to the specified model
+    """
+    if queryset.query.is_empty():
+        # Nothing to remove if queryset is empty e.g.: ...objects.none()
+        return queryset
+
+    queryset = deepcopy(queryset)  # remove the QuerySet's cache
+    query = queryset.query
+
+    def filter_lookups(node):
+        if hasattr(node, 'lhs'):
+            return node.lhs.target.model != model
 
         if isinstance(node, NothingNode):
             return False


### PR DESCRIPTION
This method functions similar to `remove_filter`, but also allows deletion of checks on related models.
