### PR TITLE
ues assert_html_snapshot in assert_html_response_snapshot and default to #content container

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.html_assertion
 
-* [`HtmlAssertionMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L30-L132) - Unittest mixin class with useful assertments around Django test client tests
-* [`assert_html_response_snapshot()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L9-L27) - Assert a HttpResponse via snapshot file using assert_html_snapshot() from bx_py_utils.
+* [`HtmlAssertionMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L38-L140) - Unittest mixin class with useful assertments around Django test client tests
+* [`assert_html_response_snapshot()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/html_assertion.py#L9-L35) - Assert a HttpResponse via snapshot file using assert_html_snapshot() from bx_py_utils.
 
 #### bx_django_utils.test_utils.model_clean_assert
 

--- a/bx_django_utils/test_utils/html_assertion.py
+++ b/bx_django_utils/test_utils/html_assertion.py
@@ -6,20 +6,28 @@ from django.contrib.messages import get_messages
 from django.http import HttpResponse
 
 
-def assert_html_response_snapshot(response: HttpResponse, status_code=200, **kwargs):
+def assert_html_response_snapshot(
+    response: HttpResponse,
+    status_code=200,
+    query_selector='#content',
+    **kwargs
+):
     """
     Assert a HttpResponse via snapshot file using assert_html_snapshot() from bx_py_utils.
+    Defaults to the `#content` container. Make sure to specify your own `query_selector=''` if you
+    need to test other parts of the HTML document.
     e.g.:
         response = self.client.get(path='/foo/bar/')
         assert_html_response_snapshot(response, validate=False)
 
     Hint: Validation will fail with default Django admin templates.
     """
-    if response.content:  # e.g.: 302 has no content ;)
+    if response.content:  # e.g.: 302 has no content
         html = response.content.decode('utf-8')
         assert_html_snapshot(
             got=html,
             self_file_path=Path(__file__),
+            query_selector=query_selector,
             **kwargs
         )
     assert response.status_code == status_code, (

--- a/bx_django_utils_tests/tests/test_html_assertion.py
+++ b/bx_django_utils_tests/tests/test_html_assertion.py
@@ -96,7 +96,8 @@ class HtmlAssertionTestCase(HtmlAssertionMixin, SimpleTestCase):
                 status_code=200,
                 root_dir=root_dir,
                 snapshot_name=snapshot_name,
-                validate=False
+                validate=False,
+                query_selector=None
             )
 
         response = self.client.get(path='/admin/')
@@ -106,8 +107,9 @@ class HtmlAssertionTestCase(HtmlAssertionMixin, SimpleTestCase):
 
         # A redirect has no content, so no snapshot file will be created,
         # but the status code is checked, too:
-        assert_html_response_snapshot(response, status_code=302)
+        assert_html_response_snapshot(
+            response, status_code=302, validate=False, query_selector=None)
 
         msg = 'Status code is 302 but excepted 200'
         with self.assertRaisesMessage(AssertionError, msg):
-            assert_html_response_snapshot(response)
+            assert_html_response_snapshot(response, validate=False, query_selector=None)


### PR DESCRIPTION
- `assert_html_response_snapshot` will now only snapshot the `#content` container by default (can be overridden by setting the `query_selector=""` argument