### PR TITLE
+ snapshot_table_counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.assert_queries
 
-* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L31-L270) - Assert executed database queries: Check table names, duplicate/similar Queries.
+* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L34-L281) - Assert executed database queries: Check table names, duplicate/similar Queries.
 
 #### bx_django_utils.test_utils.cache
 

--- a/bx_django_utils/test_utils/assert_queries.py
+++ b/bx_django_utils/test_utils/assert_queries.py
@@ -2,7 +2,10 @@ import collections
 import re
 from collections import Counter
 from difflib import unified_diff
+from pathlib import Path
 from typing import List, Optional, Tuple, Union
+
+from bx_py_utils.test_utils.snapshot import assert_snapshot
 
 from bx_django_utils.dbperf.query_recorder import SQLQueryRecorder
 from bx_django_utils.stacktrace import StacktraceAfter
@@ -189,6 +192,14 @@ class AssertQueries(SQLQueryRecorder):
                 tofile='current table counts'
             )
             raise AssertionError(self.build_error_message(f'Table count error:\n{diff}'))
+
+    def snapshot_table_counts(self, *, exclude: Optional[Tuple[str]] = None, **kwargs):
+        table_name_count = self.count_table_names()
+        if exclude:
+            for k in exclude:
+                if k in table_name_count:
+                    del table_name_count[k]
+        assert_snapshot(got=table_name_count, self_file_path=Path(__file__), **kwargs)
 
     def assert_not_double_tables(self):
         """

--- a/bx_django_utils_tests/tests/test_assert_queries_snapshot_table_counts_1.snapshot.json
+++ b/bx_django_utils_tests/tests/test_assert_queries_snapshot_table_counts_1.snapshot.json
@@ -1,0 +1,3 @@
+{
+    "auth_permission": 2
+}

--- a/bx_django_utils_tests/tests/test_assert_queries_snapshot_table_counts_2.snapshot.json
+++ b/bx_django_utils_tests/tests/test_assert_queries_snapshot_table_counts_2.snapshot.json
@@ -1,0 +1,4 @@
+{
+    "auth_group": 1,
+    "auth_permission": 3
+}


### PR DESCRIPTION
Add a helper function to snapshot the table counts of queries, for when we have a large query table count assertion that often changes, e.g. for importing all languages.
