### PR TITLE
use datetime.timezone.utc instead of django util

### DIFF
--- a/bx_django_utils/templatetags/humanize_time.py
+++ b/bx_django_utils/templatetags/humanize_time.py
@@ -4,7 +4,7 @@ from django.template import Library
 from django.utils import dateformat
 from django.utils.formats import get_format
 from django.utils.html import format_html
-from django.utils.timezone import is_aware, utc
+from django.utils.timezone import is_aware
 
 from bx_django_utils.humanize.time import human_timedelta
 
@@ -31,7 +31,7 @@ def human_duration(value, arg=None):
         if arg and not isinstance(arg, datetime.datetime):
             arg = datetime.datetime(arg.year, arg.month, arg.day)
 
-        arg = arg or datetime.datetime.now(utc if is_aware(value) else None)
+        arg = arg or datetime.datetime.now(datetime.timezone.utc if is_aware(value) else None)
 
         delta_str = human_timedelta(t=arg - value)
         time_str = dateformat.format(value, get_format('DATETIME_FORMAT'))


### PR DESCRIPTION
Fixes deprecation warning on Django 4.1:

`RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.`