### PR TITLE
Set UserTimeZone cookie with "samesite=Lax"

### DIFF
--- a/bx_django_utils/user_timezone/static/user_timezone.js
+++ b/bx_django_utils/user_timezone/static/user_timezone.js
@@ -3,5 +3,5 @@
 (() => {
     // Just store the current user time zone into a cookie
     const time_zone=Intl.DateTimeFormat().resolvedOptions().timeZone;
-    document.cookie = "UserTimeZone=" + time_zone + ";path=/;samesite=strict";
+    document.cookie = "UserTimeZone=" + time_zone + ";path=/;samesite=Lax";
 })();


### PR DESCRIPTION
If a external services is used for authentication (e.g. google login) and `user_timezone.js` added to login page, then it's needed to set a "Lax" cookie. Otherwise the browser didn't send it after login ;)