### PR TITLE
Clarify about "DJANGO_ALLOW_ASYNC_UNSAFE"

### DIFF
--- a/bx_django_utils_tests/test_project/settings.py
+++ b/bx_django_utils_tests/test_project/settings.py
@@ -154,6 +154,10 @@ LOGGING = {
 }
 
 
-# FIXME: Work-a-round for Playwright tests
-# Avoid django.core.exceptions.SynchronousOnlyOperation:
+# Playwright browser tests
+# ----------------------------------------------------------------------------
+# Avoid django.core.exceptions.SynchronousOnlyOperation. Playwright uses an event loop,
+# even when using the sync API. Django only checks whether _any_ event loop is running,
+# but not if _itself_ is running in an even loop.
+# see https://github.com/microsoft/playwright-python/issues/439#issuecomment-763339612.
 os.environ.setdefault('DJANGO_ALLOW_ASYNC_UNSAFE', '1')


### PR DESCRIPTION
Clarify why we set "DJANGO_ALLOW_ASYNC_UNSAFE", see: https://github.com/microsoft/playwright-python/issues/439#issuecomment-763339612