### PR TITLE
Enhance RenewAllFixturesBaseCommand(): User can select fixtures by input

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ Utilities / helper for writing tests.
 
 Utilities to manage text fixtures in JSON files.
 
-* [`BaseFixtures()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L28-L61) - Base class for JSON dump fixtures.
-* [`FixturesRegistry()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L98-L128) - Registry to collect a list of all existing fixture classes.
-* [`RenewAllFixturesBaseCommand()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L160-L210) - A base Django manage command to renew all existing fixture JSON dump files
-* [`SerializerFixtures()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L64-L95) - Helper to store/restore model instances serialized into a JSON file.
-* [`autodiscover()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L134-L157) - Register all fixtures by import all **/fixtures/**/*.py files
+* [`BaseFixtures()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L28-L65) - Base class for JSON dump fixtures.
+* [`FixturesRegistry()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L102-L140) - Registry to collect a list of all existing fixture classes.
+* [`RenewAllFixturesBaseCommand()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L172-L248) - A base Django manage command to renew all existing fixture JSON dump files
+* [`SerializerFixtures()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L68-L99) - Helper to store/restore model instances serialized into a JSON file.
+* [`autodiscover()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/fixtures.py#L146-L169) - Register all fixtures by import all **/fixtures/**/*.py files
 
 #### bx_django_utils.test_utils.forms
 

--- a/bx_django_utils_tests/test_app/tests/test_fixtures_helper_renew_all_1.snapshot.txt
+++ b/bx_django_utils_tests/test_app/tests/test_fixtures_helper_renew_all_1.snapshot.txt
@@ -1,0 +1,12 @@
+Found 2 fixtures files.
+____________________________________________________________________________________________________
+1. renew "fixture1" file "/path/to/fixture1...
+Mocked renew "fixture1"
+____________________________________________________________________________________________________
+2. renew "fixture2" file "/path/to/fixture2...
+Mocked renew "fixture2"
+____________________________________________________________________________________________________
+3. renew "fixture3" file "/path/to/fixture3...
+Mocked renew "fixture3"
+
+3 Fixtures updated, ok.

--- a/bx_django_utils_tests/test_app/tests/test_fixtures_helper_renew_all_with_regex_1.snapshot.txt
+++ b/bx_django_utils_tests/test_app/tests/test_fixtures_helper_renew_all_with_regex_1.snapshot.txt
@@ -1,0 +1,6 @@
+Found 2 fixtures files.
+____________________________________________________________________________________________________
+1. renew "fixture2" file "/path/to/fixture2...
+Mocked renew "fixture2"
+
+1 Fixtures updated, ok.

--- a/bx_django_utils_tests/test_app/tests/test_fixtures_helper_renew_command_1.snapshot.txt
+++ b/bx_django_utils_tests/test_app/tests/test_fixtures_helper_renew_command_1.snapshot.txt
@@ -1,7 +1,0 @@
-Found 2 fixtures files.
-____________________________________________________________________________________________________
-1. renew "ExampleFixtures1" file "example_fixtures1.json...
-____________________________________________________________________________________________________
-2. renew "ExampleFixtures2" file "example_fixtures2.json...
-
-2 Fixtures updated, ok.

--- a/bx_django_utils_tests/test_app/tests/test_fixtures_helper_select_fixtures_1.snapshot.txt
+++ b/bx_django_utils_tests/test_app/tests/test_fixtures_helper_select_fixtures_1.snapshot.txt
@@ -1,0 +1,19 @@
+Found 2 fixtures files.
+Please select:
+
+  0 - fixture1
+  1 - fixture2
+  2 - fixture3
+
+(ENTER nothing for renew all fixtures)
+Input one or more numbers seperated with spaces: 1 2
+
+You selection: fixture2, fixture3
+____________________________________________________________________________________________________
+1. renew "fixture2" file "/path/to/fixture2...
+Mocked renew "fixture2"
+____________________________________________________________________________________________________
+2. renew "fixture3" file "/path/to/fixture3...
+Mocked renew "fixture3"
+
+2 Fixtures updated, ok.

--- a/bx_django_utils_tests/test_app/tests/test_fixtures_helper_select_fixtures_2.snapshot.txt
+++ b/bx_django_utils_tests/test_app/tests/test_fixtures_helper_select_fixtures_2.snapshot.txt
@@ -1,0 +1,22 @@
+Found 2 fixtures files.
+Please select:
+
+  0 - fixture1
+  1 - fixture2
+  2 - fixture3
+
+(ENTER nothing for renew all fixtures)
+Input one or more numbers seperated with spaces: 
+
+Renew all fixtures:
+____________________________________________________________________________________________________
+1. renew "fixture1" file "/path/to/fixture1...
+Mocked renew "fixture1"
+____________________________________________________________________________________________________
+2. renew "fixture2" file "/path/to/fixture2...
+Mocked renew "fixture2"
+____________________________________________________________________________________________________
+3. renew "fixture3" file "/path/to/fixture3...
+Mocked renew "fixture3"
+
+3 Fixtures updated, ok.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "43"
+version = "44"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
Calling `./manage.sh renew_fixtures` without `--all` will display a list of all registered fixtures and the user can "select" them by input space seperated list of numbers. Looks like:
```
Found 2 fixtures files.
Please select:

  0 - ExampleFixtures1
  1 - ExampleFixtures2

(ENTER nothing for renew all fixtures)
Input one or more numbers seperated with spaces:
```

It can be combined with the existing `--filter REGEX` and the "select question" can be skipped by using `--all` argument.