### PR TITLE
Optimize FeatureFlag caching and bugfix FeatureFlagTestCaseMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L121) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L128) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 
-* [`FeatureFlagTestCaseMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/test_utils.py#L15-L37) - Mixin for `TestCase` that will change `FeatureFlag` entries. To make the tests atomic.
-* [`get_feature_flag_states()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/test_utils.py#L7-L12) - Collects information about all registered feature flags and their current state.
+* [`FeatureFlagTestCaseMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/test_utils.py#L35-L72) - Mixin for `TestCase` that will change `FeatureFlag` entries. To make the tests atomic.
+* [`get_feature_flag_states()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/test_utils.py#L12-L17) - Collects information about all registered feature flags and their current state.
 
 ### bx_django_utils.filename
 

--- a/bx_django_utils/feature_flags/tests/test_feature_flags.py
+++ b/bx_django_utils/feature_flags/tests/test_feature_flags.py
@@ -1,6 +1,7 @@
 import logging
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -8,8 +9,9 @@ from bx_django_utils.feature_flags import data_classes
 from bx_django_utils.feature_flags.data_classes import FeatureFlag
 from bx_django_utils.feature_flags.exceptions import NotUniqueFlag
 from bx_django_utils.feature_flags.state import State
-from bx_django_utils.feature_flags.test_utils import FeatureFlagTestCaseMixin
+from bx_django_utils.feature_flags.test_utils import FeatureFlagTestCaseMixin, get_feature_flag_db_info
 from bx_django_utils.feature_flags.utils import validate_cache_key
+from bx_django_utils.test_utils.assert_queries import AssertQueries
 
 
 class FeatureFlagsTestCase(FeatureFlagTestCaseMixin, TestCase):
@@ -121,3 +123,63 @@ class FeatureFlagsTestCase(FeatureFlagTestCaseMixin, TestCase):
         self.assertIn(
             'Get cache key \'feature-flags-test-initial_enabled\' failed: Cache down', output
         )
+
+    def test_cache_usage(self):
+        # Test if cache works, in current test setup:
+        self.assertIsNone(cache.get('foobar'))
+        cache.set('foobar', 1)
+        self.assertEqual(cache.get('foobar'), 1)
+
+        # Test if FeatureFlag used the cache:
+        CACHE_KEY = 'feature-flags-foo'
+
+        # Create the flag:
+
+        flag = FeatureFlag(cache_key='foo', human_name='foo', initial_enabled=False)
+        self.assertEqual(flag.cache_key, CACHE_KEY)
+
+        # Initializing will *not* store anything:
+        self.assertIsNone(cache.get(CACHE_KEY))
+        self.assertEqual(get_feature_flag_db_info(), {})
+
+        # Fetch stage -> Store in cache + database:
+        with AssertQueries() as queries:
+            self.assertFalse(flag.is_enabled)  # Initial: disabled
+
+        # First time init takes 3 queries:
+        query_count = 1  # Lookup value
+        query_count += 1  # create_or_update2() second lookup
+        query_count += 1  # create_or_update2() insert
+        queries.assert_queries(
+            table_counts={'feature_flags_featureflagmodel': query_count},
+            double_tables=False,
+        )
+
+        # Now it's in the cache:
+        self.assertIs(cache.get(CACHE_KEY), 0)
+        # ...and in the database:
+        self.assertEqual(get_feature_flag_db_info(), {'feature-flags-foo': 0})
+
+        # Check flag again should only hit the cache:
+        with AssertQueries() as queries:
+            self.assertFalse(flag.is_enabled)  # Still disabled?
+        queries.assert_queries(table_counts={})  # No Queries made?
+
+        # Change the flag should store the new stage in cache + database:
+        with AssertQueries() as queries:
+            flag.enable()
+        query_count = 1  # create_or_update2() lookup
+        query_count += 1  # create_or_update2() change values
+        queries.assert_queries(
+            table_counts={'feature_flags_featureflagmodel': query_count},
+            double_tables=False,
+        )
+        # Changed in the cache:
+        self.assertIs(cache.get(CACHE_KEY), 1)
+        # ...and in the database:
+        self.assertEqual(get_feature_flag_db_info(), {'feature-flags-foo': 1})
+
+        # Query will only use the cache:
+        with AssertQueries() as queries:
+            self.assertTrue(flag.is_enabled)  # Now it's enabled
+        queries.assert_queries(table_counts={})  # No Queries made?


### PR DESCRIPTION
Before this PR the state of a FeatureFlag was only stored into the cache on state change.

The result is, that every `.is_enabled` call will hit the database until the state was change for
the first time.

Change this and store the state to cache + database on first usage.

Also set a per-process and thread-safe cache backend for tests. This is needed if tests runs with
`--parallel` add.
Ass helper `get_feature_flag_cache_info()` and `get_feature_flag_db_info()` Think they are only
needed in own tests, so i didn't add a DocString to hide them from README.