### PR TITLE
Enhance translation helper

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -61,5 +61,6 @@ jobs:
     - name: 'Run tests with Python ${{ matrix.python-version }} Django ${{ matrix.django }}'
       run: poetry run tox -e python-django${{ matrix.django }}
 
-    - name: 'Upload coverage report'
-      run: bash <(curl -s https://codecov.io/bash)
+    - name: Upload coverage
+      uses: codecov/codecov-action@v3
+      # https://github.com/marketplace/actions/codecov

--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ Use Playwright in Unittest + Fast Django user login
 
 ### bx_django_utils.translation
 
-* [`FieldTranslation()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L68-L81) - Dict-like container that maps language codes to a translated string.
-* [`TranslationField()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L84-L142) - A field designed to hold translations for a given set of language codes.
-* [`TranslationFieldAdmin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L145-L206) - Provides drop-in support for ModelAdmin classes that want to display TranslationFields
+* [`FieldTranslation()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L68-L86) - Dict-like container that maps language codes to a translated string.
+* [`TranslationField()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L89-L152) - A field designed to hold translations for a given set of language codes.
+* [`TranslationFieldAdmin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L155-L216) - Provides drop-in support for ModelAdmin classes that want to display TranslationFields
 * [`TranslationFormField()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/translation.py#L40-L65) - Default form field for TranslationField.
 
 ### bx_django_utils.user_timezone

--- a/bx_django_utils_tests/tests/__init__.py
+++ b/bx_django_utils_tests/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+import unittest
+
+
+# Hacky way to display more "assert"-Context in failing tests:
+unittest.util._MAX_LENGTH = os.environ.get('UNITTEST_MAX_LENGTH', 200)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,13 +90,21 @@ lines_after_imports=2
 
 [tool.coverage.run]
 branch = true
+parallel = true
 source_pkgs=['bx_django_utils']
-omit = ['.*', '*/tests/*','*/migrations/*']
-command_line = 'manage.py test --parallel --shuffle'
+command_line = 'manage.py test --parallel'
 
 [tool.coverage.report]
+omit = ['.*', '*/tests/*','*/migrations/*']
 skip_empty = true
-fail_under = 45
+fail_under = 30
+show_missing = true
+exclude_lines = [
+    'if self.debug:',
+    'pragma: no cover',
+    'raise NotImplementedError',
+    'if __name__ == .__main__.:',
+]
 
 
 [tool.tox]  # https://tox.wiki/en/latest/config.html#pyproject-toml
@@ -122,7 +130,10 @@ deps =
     coverage[toml]
     poetry-publish
 commands =
-    python -m coverage run --rcfile=pyproject.toml manage.py test --parallel
+    {envpython} -m coverage run --context='{envname}'
+    {envpython} -m coverage combine --append
+    {envpython} -m coverage xml
+    {envpython} -m coverage report
 """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "46"
+version = "47"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
raise `ValidationError` if unknown translations should be stored. For normal usage this should never
happen, because the user get's a form only with known languages.
Before this PR the `_reduce_to_known_languages()` is a kind of suppressed error: It just removed all
"unknown" lanuages, but totally silent. Because of this, I spent a long time looking for a bug in my
own code. But I had only used an unsupported language in the test.

Bind '<UNTRANSLATED>' string to `FieldTranslation.UNTRANSLATED` so it can be used from external code
to compare.

Add a `FieldTranslation.__repr__` and make it helpful for compare in tests.

Add more tests and set `unittest.util._MAX_LENGTH` for better test output.