### PR TITLE
Bugfix TranslationWidget ordering

### DIFF
--- a/bx_django_utils/translation.py
+++ b/bx_django_utils/translation.py
@@ -15,7 +15,7 @@ from bx_django_utils.models.manipulate import CreateOrUpdateResult, FieldUpdate,
 class TranslationWidget(forms.Widget):
     template_name = 'bx_django_utils/translation_input.html'
 
-    def __init__(self, language_codes, attrs=None):
+    def __init__(self, language_codes: tuple, attrs=None):
         self.language_codes = language_codes
         super().__init__(attrs=attrs)
 
@@ -102,10 +102,10 @@ class TranslationField(models.JSONField):
     a regular dict (much like FileField returns a FieldFile instance).
     """
 
-    def __init__(self, language_codes, *args, **kwargs):
+    def __init__(self, language_codes: tuple, *args, **kwargs):
         kwargs['null'] = False
         kwargs['default'] = FieldTranslation
-        self.language_codes = frozenset(language_codes)
+        self.language_codes = language_codes
         self.widget_class = kwargs.pop('widget_class', TranslationWidget)
         super().__init__(*args, **kwargs)
 

--- a/bx_django_utils_tests/tests/test_translation_language_codes_order_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_translation_language_codes_order_1.snapshot.html
@@ -1,0 +1,28 @@
+<table>
+ <tbody>
+  <tr>
+   <td>
+    fr-fr
+   </td>
+   <td>
+    <input id="id_foobar__fr-fr" name="foobar__fr-fr" type="text" value=""/>
+   </td>
+  </tr>
+  <tr>
+   <td>
+    de-de
+   </td>
+   <td>
+    <input id="id_foobar__de-de" name="foobar__de-de" type="text" value=""/>
+   </td>
+  </tr>
+  <tr>
+   <td>
+    en-us
+   </td>
+   <td>
+    <input id="id_foobar__en-us" name="foobar__en-us" type="text" value=""/>
+   </td>
+  </tr>
+ </tbody>
+</table>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "49"
+version = "50"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
It was a bad idea to convert the `language_codes` into a `frozenset` because we lost the origin order.

Add a test that checks the order.