### PR TITLE
slugify -> django.utils.text.slugify

### DIFF
--- a/bx_django_utils/translation.py
+++ b/bx_django_utils/translation.py
@@ -8,9 +8,9 @@ from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.forms.fields import InvalidJSONInput
+from django.utils.text import slugify
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
-from slugify import slugify
 
 from bx_django_utils.models.manipulate import CreateOrUpdateResult, FieldUpdate, update_model_field
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "52"
+version = "53"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
By mistake, we used https://pypi.org/project/python-slugify/ Just switch to Django's `slugify()`