### PR TITLE
Crash if no poetry

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 (
-    set -x
+    set -ex
     poetry run python --version
     poetry run django-admin --version
 )


### PR DESCRIPTION
Running `./manage.sh` without poetry installed outputs

```
./manage.sh run_testserver
+ poetry run python --version
./manage.sh: 5: poetry: not found
+ poetry run django-admin --version
./manage.sh: 6: poetry: not found
./manage.sh: 9: exec: poetry: not found
make: *** [Makefile:78: start-dev-server] Error 127
```

This can't be right, abort if we can't even run python.
