### PR TITLE
remove_model_filter: Fix KeyTextTransform (TOC-7250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Utilities to manipulate objects in database via models:
 #### bx_django_utils.models.queryset_utils
 
 * [`remove_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L8-L33) - Remove an applied .filter() from a QuerySet
-* [`remove_model_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L36-L58) - Remove an applied .filter() from a QuerySet if it contains references to the specified model
+* [`remove_model_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L36-L63) - Remove an applied .filter() from a QuerySet if it contains references to the specified model
 
 #### bx_django_utils.models.timetracking
 

--- a/bx_django_utils/models/queryset_utils.py
+++ b/bx_django_utils/models/queryset_utils.py
@@ -46,7 +46,12 @@ def remove_model_filter(queryset: QuerySet, model: Type[Model]) -> QuerySet:
 
     def filter_lookups(node):
         if hasattr(node, 'lhs'):
-            return node.lhs.target.model != model
+            if hasattr(node.lhs, 'target'):
+                return node.lhs.target.model != model
+            elif hasattr(node.lhs, 'lhs'):
+                return filter_lookups(node.lhs)
+            else:
+                return True  # This branch is fine
 
         if isinstance(node, NothingNode):
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "61"
+version = "62"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
Previously, there were crashes with

`AttributeError: 'KeyTextTransform' object has no attribute 'target'`
