### PR TITLE
Bugfix AssertQueries.get_table_name() for M2M update query

### DIFF
--- a/bx_django_utils/test_utils/assert_queries.py
+++ b/bx_django_utils/test_utils/assert_queries.py
@@ -77,7 +77,7 @@ class AssertQueries(SQLQueryRecorder):
             # transaction statements
             return
 
-        table_names = re.findall(r'(FROM|INSERT INTO|UPDATE) \"(.+?)\"', sql)
+        table_names = re.findall(r'(FROM|INSERT[A-Z ]+?INTO|UPDATE) \"(.+?)\"', sql)
         assert len(table_names) >= 1, f'Error parsing: {sql!r}'
         # Use only the first table name (e.g.: ignore names in inner join)
         table_name = table_names[0][1]

--- a/bx_django_utils_tests/tests/test_assert_queries.py
+++ b/bx_django_utils_tests/tests/test_assert_queries.py
@@ -37,6 +37,20 @@ class AssertQueriesTestCase(TestCase):
             similar=True,
         )
 
+    def test_get_table_name(self):
+        self.assertEqual(
+            AssertQueries.get_table_name(
+                query={'sql': 'INSERT INTO "table_name1" ("foo_id", "bar_id") VALUES (1, 2)'}
+            ),
+            'table_name1',
+        )
+        self.assertEqual(
+            AssertQueries.get_table_name(
+                query={'sql': 'INSERT OR IGNORE INTO "table_name2" ("foo_id", "bar_id") VALUES (1, 2)'}
+            ),
+            'table_name2',
+        )
+
     def test_assert_table_names(self):
         queries = self.get_instance()
         queries.assert_table_names('auth_permission')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "63"
+version = "64"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
a M2M `set()` will result in e.g.: `INSERT OR IGNORE INTO...` and `f'Error parsing: {sql!r}'` will be raised. Add support this, too.