### PR TITLE
version command: Imply --raise-error when --write-file is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Automatic local user timezone: https://github.com/boxine/bx_django_utils/blob/ma
 
 ### bx_django_utils.version
 
-* [`DetermineVersionCommand()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/version.py#L50-L71) - The base class from which all management commands ultimately
+* [`DetermineVersionCommand()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/version.py#L50-L77) - The base class from which all management commands ultimately
 
 #### bx_django_utils.view_utils.dynamic_menu_urls
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Automatic local user timezone: https://github.com/boxine/bx_django_utils/blob/ma
 
 ### bx_django_utils.version
 
-* [`DetermineVersionCommand()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/version.py#L50-L77) - The base class from which all management commands ultimately
+* [`DetermineVersionCommand()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/version.py#L50-L78) - Write application version determined from git as a command
 
 #### bx_django_utils.view_utils.dynamic_menu_urls
 

--- a/bx_django_utils/version.py
+++ b/bx_django_utils/version.py
@@ -58,11 +58,17 @@ class DetermineVersionCommand(BaseCommand):
             help='Instead of determining the version from scratch, read it from file if possible',
         )
         parser.add_argument('-r', '--raise-error', action='store_true', help='Fail if the version is not set')
-        parser.add_argument('-w', '--write-file', action='store_true', help=f'Write to version file ({VERSION_FILE})')
+        parser.add_argument(
+            '-w',
+            '--write-file',
+            action='store_true',
+            help=f'Write to version file ({VERSION_FILE}). Implies --raise-error (we never want to write "unknown")',
+        )
 
     def handle(self, **options):
         func = get_version if options['get_from_file'] else determine_version
-        v = func(raise_error=options['raise_error'])
+        raise_error = options['raise_error'] and options['write_file']
+        v = func(raise_error=raise_error)
 
         if options['write_file']:
             VERSION_FILE.write_text(v)

--- a/bx_django_utils/version.py
+++ b/bx_django_utils/version.py
@@ -48,6 +48,7 @@ def _git_version(cwd, raise_error=False):
 
 
 class DetermineVersionCommand(BaseCommand):
+    """ Write application version determined from git as a command """
     help = 'Determine version of this application from git'
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Nobody ever wants to write "unknown" as a version file – better to not write a version file at all and determine it on runtime.
