### PR TITLE
NEW: FreezeTimezoneNow()

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,8 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.datetime
 
-* [`MockDatetimeGenerator()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/datetime.py#L4-L50) - Mock django `timezone.now()` with generic time stamps in tests.
+* [`FreezeTimezoneNow()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/datetime.py#L59-L66) - Context manager / Decorator to mock django.utils.timezone.now() with a fixed datetime.
+* [`MockDatetimeGenerator()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/datetime.py#L10-L56) - Mock django `timezone.now()` with generic time stamps in tests.
 
 #### bx_django_utils.test_utils.fixtures
 

--- a/bx_django_utils/test_utils/datetime.py
+++ b/bx_django_utils/test_utils/datetime.py
@@ -1,4 +1,10 @@
 import datetime
+from contextlib import ContextDecorator
+from unittest.mock import patch
+
+from bx_py_utils.test_utils.context_managers import MassContextManager
+from bx_py_utils.test_utils.datetime import parse_dt
+from django.utils import timezone
 
 
 class MockDatetimeGenerator:
@@ -48,3 +54,13 @@ class MockDatetimeGenerator:
         else:
             self.now += self.offset
             return self.now
+
+
+class FreezeTimezoneNow(ContextDecorator, MassContextManager):
+    """
+    Context manager / Decorator to mock django.utils.timezone.now() with a fixed datetime.
+    """
+
+    def __init__(self, now: str = '2000-01-02T00:00:00+0000'):
+        now_dt = parse_dt(now)
+        self.mocks = (patch.object(timezone, 'now', return_value=now_dt),)

--- a/bx_django_utils_tests/tests/test_test_utils_datetime.py
+++ b/bx_django_utils_tests/tests/test_test_utils_datetime.py
@@ -1,10 +1,11 @@
 import datetime
 from unittest import mock
 
+from bx_py_utils.test_utils.datetime import parse_dt
 from django.test import SimpleTestCase
 from django.utils import timezone
 
-from bx_django_utils.test_utils.datetime import MockDatetimeGenerator
+from bx_django_utils.test_utils.datetime import FreezeTimezoneNow, MockDatetimeGenerator
 
 
 class MockDatetimeGeneratorTestCase(SimpleTestCase):
@@ -31,3 +32,18 @@ class MockDatetimeGeneratorTestCase(SimpleTestCase):
             assert timezone.now() == datetime.datetime(
                 2000, 1, 1, 0, 3, tzinfo=datetime.timezone.utc
             )
+
+    def test_freeze_timezone_now(self):
+        """
+        Test FreezeTimezoneNow
+        """
+        # Test as context manager:
+        with FreezeTimezoneNow(now='2020-01-02T12:34:56+0000'):
+            self.assertEqual(timezone.now(), parse_dt('2020-01-02T12:34:56+0000'))
+
+        # Test as decorator:
+        @FreezeTimezoneNow()
+        def get_now():
+            return timezone.now()
+
+        self.assertEqual(get_now(), parse_dt('2000-01-02T00:00:00+0000'))


### PR DESCRIPTION
Add a context manager / decorator to mock `django.utils.timezone.now()` with a fixed datetime.

Freezegun is nice. But the `FakeDatetime` objects may cause problems in tests.