### PR TITLE
Use timezone.now() in human_duration()

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Utilities to manipulate objects in database via models:
 
 #### bx_django_utils.templatetags.humanize_time
 
-* [`human_duration()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/templatetags/humanize_time.py#L15-L45) - Verbose time since template tag, e.g.: `<span title="Jan. 1, 2000, noon">2.0 seconds</span>`
+* [`human_duration()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/templatetags/humanize_time.py#L16-L58) - Verbose time since template tag, e.g.: `<span title="Jan. 1, 2000, noon">2.0 seconds</span>`
 
 ### bx_django_utils.test_utils
 

--- a/bx_django_utils/templatetags/humanize_time.py
+++ b/bx_django_utils/templatetags/humanize_time.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import datetime
 
 from django.template import Library
-from django.utils import dateformat
+from django.utils import dateformat, timezone
 from django.utils.formats import get_format
 from django.utils.html import format_html
-from django.utils.timezone import is_aware
 
 from bx_django_utils.humanize.time import human_timedelta
 
@@ -13,12 +14,18 @@ register = Library()
 
 
 @register.filter
-def human_duration(value, arg=None):
+def human_duration(
+    value: datetime.date | datetime.datetime | None,
+    arg: datetime.date | datetime.datetime | None = None,
+):
     """
     Verbose time since template tag, e.g.: `<span title="Jan. 1, 2000, noon">2.0 seconds</span>`
 
     e.g.:
         <span title="Jan. 1, 2000, noon">2.0 seconds</span>
+
+    value and arg can be datetime.datetime or datetime.date.
+    and can be timezone aware or naive.
     """
     if not value:
         return ''
@@ -28,10 +35,16 @@ def human_duration(value, arg=None):
         if not isinstance(value, datetime.datetime):
             value = datetime.datetime(value.year, value.month, value.day)
 
-        if arg and not isinstance(arg, datetime.datetime):
+        if arg is None:
+            arg = timezone.now()
+        elif not isinstance(arg, datetime.datetime):
             arg = datetime.datetime(arg.year, arg.month, arg.day)
 
-        arg = arg or datetime.datetime.now(datetime.timezone.utc if is_aware(value) else None)
+        if timezone.is_aware(value) and timezone.is_naive(arg):
+            value = timezone.make_naive(value)
+
+        if timezone.is_naive(value) and timezone.is_aware(arg):
+            arg = timezone.make_naive(arg)
 
         delta_str = human_timedelta(t=arg - value)
         time_str = dateformat.format(value, get_format('DATETIME_FORMAT'))

--- a/bx_django_utils_tests/tests/test_templatetags_humanize_time.py
+++ b/bx_django_utils_tests/tests/test_templatetags_humanize_time.py
@@ -1,27 +1,39 @@
 import datetime
+from unittest.mock import patch
 
 from bx_py_utils.test_utils.datetime import parse_dt
 from django.test import SimpleTestCase
-from django.utils import translation
+from django.utils import timezone, translation
 
 from bx_django_utils.templatetags.humanize_time import human_duration
 
 
 class HumanizeTimeTestCase(SimpleTestCase):
-    def test_basic(self):
-        with translation.override('en'):
-            result = human_duration(
-                parse_dt('2000-01-01T12:00:00+0000'),
-                parse_dt('2000-01-01T12:10:00+0000'),
-            )
-            assert result == '<span title="Jan. 1, 2000, noon">10.0\xa0minutes</span>'
+    @translation.override('en')
+    def test_mixed(self):
+        # convert mixed offset-naive and offset-aware times:
+        foo_dt = parse_dt('2000-01-01T12:00:00+0000')
+        assert timezone.is_aware(foo_dt), f'{foo_dt=}'
 
-        with translation.override('en'):
-            result = human_duration(
-                parse_dt('2000-01-01T12:00:00+0000'),
-                parse_dt('2000-01-01T12:00:02+0000'),
-            )
-            assert result == '<span title="Jan. 1, 2000, noon">2.0\xa0seconds</span>'
+        result = human_duration(value=timezone.make_naive(foo_dt), arg=foo_dt)
+        self.assertEqual(result, '<span title="Jan. 1, 2000, noon">0.0\xa0ms</span>')
+
+        result = human_duration(value=foo_dt, arg=timezone.make_naive(foo_dt))
+        self.assertEqual(result, '<span title="Jan. 1, 2000, noon">0.0\xa0ms</span>')
+
+    @translation.override('en')
+    def test_basic(self):
+        result = human_duration(
+            parse_dt('2000-01-01T12:00:00+0000'),
+            parse_dt('2000-01-01T12:10:00+0000'),
+        )
+        self.assertEqual(result, '<span title="Jan. 1, 2000, noon">10.0\xa0minutes</span>')
+
+        result = human_duration(
+            parse_dt('2000-01-01T12:00:00+0000'),
+            parse_dt('2000-01-01T12:00:02+0000'),
+        )
+        self.assertEqual(result, '<span title="Jan. 1, 2000, noon">2.0\xa0seconds</span>')
 
         with translation.override('de'):
             result = human_duration(
@@ -30,24 +42,28 @@ class HumanizeTimeTestCase(SimpleTestCase):
             )
             self.assertEqual(result, '<span title="1. Januar 2000 12:00">10.0\xa0Minuten</span>')
 
-        with translation.override('en'):
-            result = human_duration(
-                parse_dt('2000-01-01T12:32:12+0000'),
-                parse_dt('2000-01-01T12:20:10+0000'),
-            )
-            assert result == '<span title="Jan. 1, 2000, 12:32 p.m.">-12.0\xa0minutes</span>'
+        result = human_duration(
+            parse_dt('2000-01-01T12:32:12+0000'),
+            parse_dt('2000-01-01T12:20:10+0000'),
+        )
+        self.assertEqual(result, '<span title="Jan. 1, 2000, 12:32 p.m.">-12.0\xa0minutes</span>')
 
-        with translation.override('en'):
-            years_back = datetime.datetime.now() - datetime.timedelta(days=5 * 365)
-            result = human_duration(years_back)
-            assert result.endswith('>5.0\xa0years</span>')
+        years_back = timezone.now() - datetime.timedelta(days=5 * 365)
+        result = human_duration(years_back)
+        assert result.endswith('>5.0\xa0years</span>'), f'{result=}'
 
-        assert human_duration(None) == ''
-        assert human_duration(value=object) == ''
+        result = human_duration(
+            datetime.date(2000, 1, 1),
+            datetime.date(2000, 6, 15),
+        )
+        self.assertEqual(result, '<span title="Jan. 1, 2000, midnight">5.5\xa0months</span>')
 
-        with translation.override('en'):
-            result = human_duration(
-                datetime.date(2000, 1, 1),
-                datetime.date(2000, 6, 15),
-            )
-            assert result == '<span title="Jan. 1, 2000, midnight">5.5\xa0months</span>'
+        # Mock timezone.now should work:
+        now = parse_dt('2000-01-01T00:00:00+0000')
+        with patch.object(timezone, 'now', return_value=now):
+            result = human_duration(now)
+        self.assertEqual(result, '<span title="Jan. 1, 2000, midnight">0.0\xa0ms</span>')
+
+        # Check error handling:
+        self.assertEqual(human_duration(None), '')
+        self.assertEqual(human_duration(value=object), '')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "66"
+version = "67"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
Because `timezone.now()` can be easier mocked ;)

Also support all mixes of `datetime` vs. `date` and timezone aware vs. naive variants. Modernize and expand tests.