### PR TITLE
Validate UserTimeZone cookie value before pass it to ZoneInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,9 @@ Automatic local user timezone: https://github.com/boxine/bx_django_utils/blob/ma
 
 #### bx_django_utils.user_timezone.middleware
 
-* [`UserTimezoneMiddleware()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/user_timezone/middleware.py#L10-L31) - Activate Timezone by "UserTimeZone" cookie
+* [`InvalidUserTimeZone()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/user_timezone/middleware.py#L11-L12) - Inappropriate argument value (of correct type).
+* [`UserTimezoneMiddleware()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/user_timezone/middleware.py#L34-L68) - Activate Timezone by "UserTimeZone" cookie
+* [`validate()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/user_timezone/middleware.py#L15-L31) - Validate the UserTimeZone cookie value.
 
 ##### bx_django_utils.user_timezone.templatetags.user_timezone
 

--- a/bx_django_utils/user_timezone/middleware.py
+++ b/bx_django_utils/user_timezone/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import zoneinfo
 
 from django.utils import timezone
@@ -7,16 +8,44 @@ from django.utils import timezone
 logger = logging.getLogger(__name__)
 
 
+class InvalidUserTimeZone(ValueError):
+    pass
+
+
+def validate(raw_time_zone: str, min_length: int, max_length: int, usertimezone_re: str) -> None:
+    """
+    Validate the UserTimeZone cookie value.
+    """
+    length = len(raw_time_zone)
+
+    if length > max_length:
+        raise InvalidUserTimeZone(f'Expected max length {max_length}, got {length}')
+
+    if length < min_length:
+        raise InvalidUserTimeZone(f'Expected min length {min_length}, got {length}')
+
+    if not raw_time_zone.isascii():
+        raise InvalidUserTimeZone('Only ASCII chars allowed')
+
+    if not re.fullmatch(usertimezone_re, raw_time_zone):
+        raise InvalidUserTimeZone(f'Not match: {raw_time_zone}')
+
+
 class UserTimezoneMiddleware:
     """
     Activate Timezone by "UserTimeZone" cookie
     """
+
+    MIN_LENGTH = 2  # e.g.: "NZ", "GB", etc.
+    MAX_LENGTH = 32  # e.g.: "America/Argentina/ComodRivadavia"
+    USERTIMEZONE_RE = r'[a-zA-Z0-9_\-\+/]+'  # e.g.: "Etc/GMT+10", "US/East-Indiana", "Europe/San_Marino"
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         if raw_time_zone := request.COOKIES.get('UserTimeZone'):
+            self.validate(raw_time_zone)
             try:
                 tzinfo = zoneinfo.ZoneInfo(raw_time_zone)
             except zoneinfo.ZoneInfoNotFoundError:
@@ -29,3 +58,11 @@ class UserTimezoneMiddleware:
 
         # Response with default timezone:
         return self.get_response(request)
+
+    def validate(self, raw_time_zone):
+        validate(
+            raw_time_zone=raw_time_zone,
+            min_length=self.MIN_LENGTH,
+            max_length=self.MAX_LENGTH,
+            usertimezone_re=self.USERTIMEZONE_RE,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "69"
+version = "70"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [


### PR DESCRIPTION
We can't trust value of `request.COOKIES['UserTimeZone']` :)

The ZoneInfo will also check this, but pass them just to `os.path` functions. Before this we can check some basics, that this is in normal length range and has no ugly characters. Better save than sorry ;)