### PR TITLE
assert_queries: Handle unquoted table names

### DIFF
--- a/bx_django_utils/test_utils/assert_queries.py
+++ b/bx_django_utils/test_utils/assert_queries.py
@@ -78,10 +78,11 @@ class AssertQueries(SQLQueryRecorder):
             # transaction statements
             return
 
-        table_names = re.findall(r'(FROM|INSERT[A-Z ]+?INTO|UPDATE) \"(.+?)\"', sql)
-        assert len(table_names) >= 1, f'Error parsing: {sql!r}'
-        # Use only the first table name (e.g.: ignore names in inner join)
-        table_name = table_names[0][1]
+        table_name_match = re.search(
+            r'(?:FROM|INSERT[A-Z ]+?INTO|UPDATE)\s+(?:(?P<unquoted>[a-zA-Z][_\w]+)|\"(?P<quoted>.+?)\")', sql
+        )
+        assert table_name_match, f'Error parsing: {sql!r}'
+        table_name = table_name_match.group('unquoted') or table_name_match.group('quoted')
         return table_name
 
     def count_table_names(self):

--- a/bx_django_utils_tests/tests/test_assert_queries.py
+++ b/bx_django_utils_tests/tests/test_assert_queries.py
@@ -51,6 +51,25 @@ class AssertQueriesTestCase(TestCase):
             ),
             'table_name2',
         )
+        self.assertEqual(
+            AssertQueries.get_table_name(
+                query={
+                    'sql': '''
+                    SELECT
+                     foo.id,
+                     bar.id,
+                     bar."timestamp",
+                     xuu.id
+                FROM foo
+                    INNER JOIN bar
+                        ON foo.item_id = bar.item_ptr_id
+                    INNER JOIN xuu
+                        ON bar.content_id = xuu.id
+                '''
+                }
+            ),
+            'foo',
+        )
 
     def test_assert_table_names(self):
         queries = self.get_instance()


### PR DESCRIPTION
Modern Django emits unquoted table names for some complicated queries. There is no reason why we shouldn't be able to handle that.
Simplify the quote, `findall` was not necessary since we only take the first match anyways.
