### PR TITLE
improve feature flags with some quality of life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,16 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L128) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L135) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 
 * [`FeatureFlagTestCaseMixin()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/test_utils.py#L35-L72) - Mixin for `TestCase` that will change `FeatureFlag` entries. To make the tests atomic.
 * [`get_feature_flag_states()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/test_utils.py#L12-L17) - Collects information about all registered feature flags and their current state.
+
+#### bx_django_utils.feature_flags.utils
+
+* [`if_feature()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/utils.py#L20-L38) - A decorator that only executed the decorated function if the given feature flag is enabled.
 
 ### bx_django_utils.filename
 

--- a/bx_django_utils/feature_flags/data_classes.py
+++ b/bx_django_utils/feature_flags/data_classes.py
@@ -102,6 +102,10 @@ class FeatureFlag:
             return bool(raw_value)
 
     @property
+    def is_disabled(self) -> bool:
+        return not self.is_enabled
+
+    @property
     def state(self):
         if self.is_enabled:
             return State.ENABLED
@@ -126,3 +130,6 @@ class FeatureFlag:
     @classmethod
     def get_by_cache_key(cls, cache_key) -> "FeatureFlag":
         return cls.registry[cache_key]
+
+    def __bool__(self):
+        return self.is_enabled

--- a/bx_django_utils/feature_flags/exceptions.py
+++ b/bx_django_utils/feature_flags/exceptions.py
@@ -1,4 +1,19 @@
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from bx_django_utils.feature_flags.data_classes import FeatureFlag
+
+
 class NotUniqueFlag(AssertionError):
     """"""  # noqa - don't add in README
 
     pass
+
+
+class FeatureFlagDisabled(Exception):
+    """"""  # noqa - don't add in README
+
+    def __init__(self, feature_flag: "FeatureFlag", *args, **kwargs):
+        msg = f'feature flag {feature_flag.human_name!r} is disabled'
+        super().__init__(msg, *args, **kwargs)

--- a/bx_django_utils/feature_flags/templates/admin_extra_views/manage_feature_flags.html
+++ b/bx_django_utils/feature_flags/templates/admin_extra_views/manage_feature_flags.html
@@ -4,7 +4,9 @@
 {% block content %}
 {{ form.errors }}
 {% for feature_flag in feature_flags %}
-    <h2>{{ feature_flag.human_name }} - {{ feature_flag.state.name }}</h2>
+    {% with anchor=feature_flag.human_name|slugify %}
+    <h2 id="{{ anchor }}">{{ feature_flag.human_name }} - {{ feature_flag.state.name }}&nbsp;<a href="#{{ anchor }}">&para;</a></h2>
+    {% endwith %}
     <pre>{{ feature_flag.description }}</pre>
     <p>(Initial default state: {{ feature_flag.initial_state.name }})</p>
     <p>Current state: <strong>{{ feature_flag.state.name }}</strong></p>

--- a/bx_django_utils/feature_flags/utils.py
+++ b/bx_django_utils/feature_flags/utils.py
@@ -1,8 +1,38 @@
+import functools
+from typing import TYPE_CHECKING
+
 from django.core.cache.backends.base import memcache_key_warnings
 from django.core.exceptions import ValidationError
+
+from bx_django_utils.feature_flags.exceptions import FeatureFlagDisabled
+
+
+if TYPE_CHECKING:
+    from bx_django_utils.feature_flags.data_classes import FeatureFlag
 
 
 def validate_cache_key(cache_key: str) -> None:
     messages = list(memcache_key_warnings(cache_key))
     if messages:
         raise ValidationError(messages)
+
+
+def if_feature(feature_flag: "FeatureFlag", raise_exception: bool = False):
+    """
+    A decorator that only executed the decorated function if the given feature flag is enabled.
+    Performs a noop otherwise, or raises a FeatureFlagDisabled exception if raise_exception is True.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not feature_flag.is_enabled:
+                if not raise_exception:
+                    return
+                else:
+                    raise FeatureFlagDisabled(feature_flag)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/bx_django_utils_tests/tests/test_feature_flag_integration.py
+++ b/bx_django_utils_tests/tests/test_feature_flag_integration.py
@@ -53,9 +53,9 @@ class FeatureFlagIntegrationTestCase(FeatureFlagTestCaseMixin, HtmlAssertionMixi
         self.assert_html_parts(
             response,
             parts=(
-                '<h2>Foo - ENABLED</h2>',
+                '<h2 id="foo">Foo - ENABLED&nbsp;<a href="#foo">&para;</a></h2>',
                 '<input type="submit" value="Set \'Foo\' to DISABLED">',
-                '<h2>Bar - DISABLED</h2>',
+                '<h2 id="bar">Bar - DISABLED&nbsp;<a href="#bar">&para;</a></h2>',
                 '<input type="submit" value="Set \'Bar\' to ENABLED">',
             ),
         )
@@ -130,8 +130,8 @@ class FeatureFlagIntegrationTestCase(FeatureFlagTestCaseMixin, HtmlAssertionMixi
         self.assert_html_parts(
             response,
             parts=(
-                '<h2>Foo - DISABLED</h2>',
-                '<h2>Bar - DISABLED</h2>',
+                '<h2 id="foo">Foo - DISABLED&nbsp;<a href="#foo">&para;</a></h2>',
+                '<h2 id="bar">Bar - DISABLED&nbsp;<a href="#bar">&para;</a></h2>',
                 f'<p>Last changed by test-superuser {human_duration(action_time)} ago.</p>',
             ),
         )

--- a/bx_django_utils_tests/tests/test_feature_flag_integration_basic_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_feature_flag_integration_basic_1.snapshot.html
@@ -1,6 +1,9 @@
 <div class="colM" id="content">
- <h2>
+ <h2 id="foo">
   Foo - DISABLED
+  <a href="#foo">
+   ¶
+  </a>
  </h2>
  <pre>En-/disable example Feature flag `Foo`.
 Just for demonstrate.</pre>
@@ -26,8 +29,11 @@ Just for demonstrate.</pre>
   <input name="new_value" type="hidden" value="1"/>
   <input type="submit" value="Set 'Foo' to ENABLED"/>
  </form>
- <h2>
+ <h2 id="bar">
   Bar - DISABLED
+  <a href="#bar">
+   ¶
+  </a>
  </h2>
  <pre>En-/disable example Feature flag `Bar`.</pre>
  <p>

--- a/bx_django_utils_tests/tests/test_feature_flag_integration_basic_django42_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_feature_flag_integration_basic_django42_1.snapshot.html
@@ -1,6 +1,9 @@
 <div class="colM" id="content">
- <h2>
+ <h2 id="foo">
   Foo - ENABLED
+  <a href="#foo">
+   ¶
+  </a>
  </h2>
  <pre>En-/disable example Feature flag `Foo`.
 Just for demonstrate.</pre>
@@ -19,8 +22,11 @@ Just for demonstrate.</pre>
   <input name="new_value" type="hidden" value="0"/>
   <input type="submit" value="Set 'Foo' to DISABLED"/>
  </form>
- <h2>
+ <h2 id="bar">
   Bar - DISABLED
+  <a href="#bar">
+   ¶
+  </a>
  </h2>
  <pre>En-/disable example Feature flag `Bar`.</pre>
  <p>

--- a/bx_django_utils_tests/tests/test_feature_flag_integration_basic_django50_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_feature_flag_integration_basic_django50_1.snapshot.html
@@ -1,6 +1,9 @@
 <div class="colM" id="content">
- <h2>
+ <h2 id="foo">
   Foo - ENABLED
+  <a href="#foo">
+   ¶
+  </a>
  </h2>
  <pre>En-/disable example Feature flag `Foo`.
 Just for demonstrate.</pre>
@@ -19,8 +22,11 @@ Just for demonstrate.</pre>
   <input name="new_value" type="hidden" value="0"/>
   <input type="submit" value="Set 'Foo' to DISABLED"/>
  </form>
- <h2>
+ <h2 id="bar">
   Bar - DISABLED
+  <a href="#bar">
+   ¶
+  </a>
  </h2>
  <pre>En-/disable example Feature flag `Bar`.</pre>
  <p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_django_utils'
-version = "72"
+version = "73"
 description = 'Various Django utility functions'
 homepage = "https://github.com/boxine/bx_django_utils/"
 authors = [
@@ -108,6 +108,8 @@ exclude_lines = [
     'pragma: no cover',
     'raise NotImplementedError',
     'if __name__ == .__main__.:',
+    'if TYPE_CHECKING:',
+    'if typing.TYPE_CHECKING:',
 ]
 
 


### PR DESCRIPTION
improve feature flags with some quality of life improvements

- complement `FeatureFlag.is_enabled` with the new `FeatureFlag.is_disabled`
- make the state of feature flags pythonically evaluable by implementing `FeatureFlag.__bool__`
- in the administration page, create an anchor for every flag and provide a paragraph for copying a deep link
- provide the new `@if_feature` decorator to conditionally run decorated functions (saves boilerplate evaluation code)