### PR TITLE
Configure unittests via "load_tests Protocol"

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,12 @@ Use Playwright in Unittest + Fast Django user login
 
 #### bx_django_utils.test_utils.users
 
-* [`assert_permissions()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L31-L46) - Check user permissions.
-* [`assert_user_properties()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L149-L171) - Check a user instance with all properties and password (optional)
-* [`filter_permission_names()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L10-L28) - Generate a Permission model query filtered by names, e.g.: ['<app_label>.<codename>', ...]
-* [`make_max_test_user()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L112-L146) - Create a test user with all permissions *except* the {exclude_permissions} ones.
-* [`make_minimal_test_user()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L85-L109) - Create a test user and set given permissions.
-* [`make_test_user()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L49-L82) - Create a test user and set given permissions.
+* [`assert_permissions()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L33-L48) - Check user permissions.
+* [`assert_user_properties()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L151-L173) - Check a user instance with all properties and password (optional)
+* [`filter_permission_names()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L12-L30) - Generate a Permission model query filtered by names, e.g.: ['<app_label>.<codename>', ...]
+* [`make_max_test_user()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L114-L148) - Create a test user with all permissions *except* the {exclude_permissions} ones.
+* [`make_minimal_test_user()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L87-L111) - Create a test user and set given permissions.
+* [`make_test_user()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/users.py#L51-L84) - Create a test user and set given permissions.
 
 ### bx_django_utils.translation
 

--- a/bx_django_utils/test_utils/users.py
+++ b/bx_django_utils/test_utils/users.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 
 from bx_py_utils.test_utils.assertion import assert_equal
@@ -146,7 +148,7 @@ def make_max_test_user(
     return user
 
 
-def assert_user_properties(user, properties: dict, raw_password: str = None) -> None:
+def assert_user_properties(user, properties: dict, raw_password: str | None = None) -> None:
     """
     Check a user instance with all properties and password (optional)
     """

--- a/bx_django_utils_tests/tests/__init__.py
+++ b/bx_django_utils_tests/tests/__init__.py
@@ -1,12 +1,31 @@
 import os
-import unittest
+import unittest.util
 from pathlib import Path
 
-import bx_django_utils
+from typeguard import install_import_hook
+
+# Check type annotations via typeguard in all tests:
+install_import_hook(packages=('bx_django_utils', 'bx_django_utils_tests'))
 
 
-# Hacky way to display more "assert"-Context in failing tests:
-unittest.util._MAX_LENGTH = os.environ.get('UNITTEST_MAX_LENGTH', 300)
+def pre_configure_tests() -> None:
+    print(f'Configure unittests via "load_tests Protocol" from {Path(__file__).relative_to(Path.cwd())}')
+
+    # Hacky way to display more "assert"-Context in failing tests:
+    _MIN_MAX_DIFF = unittest.util._MAX_LENGTH - unittest.util._MIN_DIFF_LEN
+    unittest.util._MAX_LENGTH = int(os.environ.get('UNITTEST_MAX_LENGTH', 600))
+    unittest.util._MIN_DIFF_LEN = unittest.util._MAX_LENGTH - _MIN_MAX_DIFF
+
+    # Deny any request via docket/urllib3 because tests they should mock all requests:
+    from bx_py_utils.test_utils.deny_requests import deny_any_real_request
+
+    deny_any_real_request()
 
 
-PACKAGE_ROOT = Path(bx_django_utils.__file__).parent.parent
+def load_tests(loader, tests, pattern):
+    """
+    Use unittest "load_tests Protocol" as a hook to setup test environment before running tests.
+    https://docs.python.org/3/library/unittest.html#load-tests-protocol
+    """
+    pre_configure_tests()
+    return loader.discover(start_dir=Path(__file__).parent, pattern=pattern)

--- a/bx_django_utils_tests/tests/test_project_setup.py
+++ b/bx_django_utils_tests/tests/test_project_setup.py
@@ -1,6 +1,8 @@
 import subprocess
 from importlib.metadata import version
+from pathlib import Path
 
+from bx_py_utils.path import assert_is_file
 from bx_py_utils.test_utils.unittest_utils import assert_no_flat_tests_functions
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
@@ -10,7 +12,9 @@ from packaging.version import Version
 
 import bx_django_utils
 from bx_django_utils.test_utils.html_assertion import HtmlAssertionMixin
-from bx_django_utils_tests.tests import PACKAGE_ROOT
+
+PACKAGE_ROOT = Path(bx_django_utils.__file__).parent.parent
+assert_is_file(PACKAGE_ROOT / 'pyproject.toml')
 
 
 class ProjectSetupTestCase(SimpleTestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ deps =
     editorconfig
     django-polymorphic
     setuptools
+    typeguard
 commands_pre =
     {envpython} -m playwright install chromium firefox
 commands =


### PR DESCRIPTION
This does:

* Activate typeguard
* Expand unittest assert context length
* Deny any requests in tests