### PR TITLE
Feature Flag: add reset()

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L18-L164) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L18-L168) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 

--- a/bx_django_utils/feature_flags/data_classes.py
+++ b/bx_django_utils/feature_flags/data_classes.py
@@ -75,6 +75,10 @@ class FeatureFlag:
         cache.set(self.cache_key, state_value, timeout=None)  # set forever
         return bool(state_value)
 
+    def reset(self) -> None:
+        FeatureFlagModel.objects.filter(cache_key=self.cache_key).delete()
+        cache.delete(self.cache_key)
+
     @property
     def is_enabled(self) -> bool:
         try:


### PR DESCRIPTION
Add a reset method that will remove the current state of the feature flag completely, e.g. to get a clean development environment.
