### PR TITLE
FeatureFlag: Add __str__ and __repr__

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L18-L168) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L18-L176) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 

--- a/bx_django_utils/feature_flags/data_classes.py
+++ b/bx_django_utils/feature_flags/data_classes.py
@@ -36,6 +36,7 @@ class FeatureFlag:
 
         validate_cache_key(cache_key)
         validate_cache_key(cache_key_prefix)
+        self.name = cache_key
         self.cache_key = f'{cache_key_prefix}-{cache_key}'
         validate_cache_key(self.cache_key)  # Double check ;)
 
@@ -166,3 +167,10 @@ class FeatureFlag:
 
     def __bool__(self):
         return self.is_enabled
+
+    def __str__(self):
+        return f'<FeatureFlag {self.name}>'
+
+    def __repr__(self):
+        initial = self.initial_state == State.ENABLED
+        return f'FeatureFlag(cache_key={self.name!r}, human_name={self.human_name!r}, initial_enabled={initial!r})'

--- a/bx_django_utils/feature_flags/tests/test_feature_flags.py
+++ b/bx_django_utils/feature_flags/tests/test_feature_flags.py
@@ -269,3 +269,12 @@ class IsolatedFeatureFlagsTestCase(FeatureFlagTestCaseMixin, TestCase):
 
         # Reset again – should not error
         flag.reset()
+
+    def test_str(self):
+        flag = FeatureFlag(
+            cache_key='be-wild',
+            human_name='Be wild',
+            initial_enabled=False,
+        )
+        self.assertEqual(str(flag), '<FeatureFlag be-wild>')
+        self.assertEqual(repr(flag), "FeatureFlag(cache_key='be-wild', human_name='Be wild', initial_enabled=False)")


### PR DESCRIPTION
Store the additional name. In retrospect, it was a bad idea to name the `__init__` kwarg `cache_key`, when that has another meaning.
