### PR TITLE
Regen dependencies with Python 3.9

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -28,19 +28,18 @@
         },
         "bx-py-utils": {
             "hashes": [
-                "sha256:508cfc1d0fa6c22298f697c4efaa913337847d488d8a53eeccfae9ee106123f6",
-                "sha256:c92ebc4fb122e3e3c228d984d0a1f5c3284c3da6aab1a1c753f7eb1f71bdab3a"
+                "sha256:6d9211f0d01a51bb83cc260b4a5293b8364ce539d60a59975fc6d95e103e9041",
+                "sha256:d603449d5e481035ae1186b34e57465f9e5f8235c4f7f1a73b98899a475b2b28"
             ],
-            "markers": "python_version >= '3.10' and python_version < '4'",
-            "version": "==104"
+            "version": "==93"
         },
         "django": {
             "hashes": [
-                "sha256:bd7376f90c99f96b643722eee676498706c9fd7dc759f55ebfaf2c08ebcdf4f0",
-                "sha256:f11aa87ad8d5617171e3f77e1d5d16f004b79a2cf5d2e1d2b97a6a1f8e9ba5ed"
+                "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898",
+                "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==5.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.16"
         },
         "python-stdnum": {
             "hashes": [
@@ -56,6 +55,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.5.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==4.12.2"
         }
     },
     "develop": {
@@ -83,6 +90,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.8.1"
         },
+        "async-timeout": {
+            "hashes": [
+                "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f",
+                "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.3"
+        },
         "attrs": {
             "hashes": [
                 "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
@@ -106,6 +121,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.3.1"
+        },
+        "backports.tarfile": {
+            "hashes": [
+                "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
+                "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991"
+            ],
+            "markers": "python_version < '3.12'",
+            "version": "==1.2.0"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -151,18 +174,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b660c649a27a6b47a34f6f858f5bd7c3b0a798a16dec8dda7cbebeee80fd1f60",
-                "sha256:ddecb27f5699ca9f97711c52b6c0652c2e63bf6c2bfbc13b819b4f523b4d30ff"
+                "sha256:14724b905fd13f26d9d8f7cdcea0fa65a9acad79f60f41f7662667f4e233d97c",
+                "sha256:4f15d1ccb481d66f6925b8c91c970ce41b956b6ecf7c479f23e2159531b37eec"
             ],
-            "version": "==1.35.49"
+            "version": "==1.35.50"
         },
         "botocore": {
             "hashes": [
-                "sha256:07d0c1325fdbfa49a4a054413dbdeab0a6030449b2aa66099241af2dac48afd8",
-                "sha256:aed4d3643afd702920792b68fbe712a8c3847993820d1048cd238a6469354da1"
+                "sha256:136ecef8d5a1088f1ba485c0bbfca40abd42b9f9fe9e11d8cde4e53b4c05b188",
+                "sha256:965d3b99179ac04aa98e4c4baf4a970ebce77a5e02bb2a0a21cb6304e2bc0955"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.49"
+            "version": "==1.35.50"
         },
         "build": {
             "hashes": [
@@ -177,11 +200,10 @@
         },
         "bx-py-utils": {
             "hashes": [
-                "sha256:508cfc1d0fa6c22298f697c4efaa913337847d488d8a53eeccfae9ee106123f6",
-                "sha256:c92ebc4fb122e3e3c228d984d0a1f5c3284c3da6aab1a1c753f7eb1f71bdab3a"
+                "sha256:6d9211f0d01a51bb83cc260b4a5293b8364ce539d60a59975fc6d95e103e9041",
+                "sha256:d603449d5e481035ae1186b34e57465f9e5f8235c4f7f1a73b98899a475b2b28"
             ],
-            "markers": "python_version >= '3.10' and python_version < '4'",
-            "version": "==104"
+            "version": "==93"
         },
         "cachetools": {
             "hashes": [
@@ -393,11 +415,11 @@
         },
         "cli-base-utilities": {
             "hashes": [
-                "sha256:a0142b46ced685fda8e7393c90d2cb1a709ea7ae37469249e3f519bd8c7844e2",
-                "sha256:abb265fee788af0e347395bd9c863370df04ddc6b8aff97e77841c994f5daee6"
+                "sha256:5c54cdd5e5122abf6a86aa6926b4b2dbc6632c113885692c8d95f531bb2b181b",
+                "sha256:95b1119d9f4bb335974faf655e853f58bdd04af0bac99d22005b6fb79b9e4b14"
             ],
-            "markers": "python_version >= '3.11'",
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.9' and python_version < '4'",
+            "version": "==0.10.3"
         },
         "click": {
             "hashes": [
@@ -560,11 +582,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:bd7376f90c99f96b643722eee676498706c9fd7dc759f55ebfaf2c08ebcdf4f0",
-                "sha256:f11aa87ad8d5617171e3f77e1d5d16f004b79a2cf5d2e1d2b97a6a1f8e9ba5ed"
+                "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898",
+                "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==5.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.16"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -579,14 +601,6 @@
                 "sha256:d6955b5308bf6e41dcb22ba7c96f00b51dfa497a8a5ab1e9c06c7951bf417bf8"
             ],
             "version": "==3.1.0"
-        },
-        "docstring-parser": {
-            "hashes": [
-                "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e",
-                "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637"
-            ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "version": "==0.16"
         },
         "docutils": {
             "hashes": [
@@ -731,7 +745,7 @@
                 "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
                 "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_full_version < '3.10.2'",
             "version": "==8.5.0"
         },
         "isort": {
@@ -942,10 +956,10 @@
         },
         "manageprojects": {
             "hashes": [
-                "sha256:4c5649deb9791f3016c1848b34080e1564ea3bec2a8e25a09f9f0af9012086df",
-                "sha256:5f9b7d692df1540b8787ae31acc9613270be01c7d4416aad77e5dee4ca97e363"
+                "sha256:355d970261f14b53b574d102e7e82462fe6769baa06c479f00f07a0bcfcb8e4d",
+                "sha256:4662ff7f0e64ea9b420b67c270594c88542858a1434ebe8b5f93b7bf2ae2e706"
             ],
-            "version": "==0.19.2"
+            "version": "==0.17.1"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1331,14 +1345,6 @@
             "markers": "python_version >= '3.9'",
             "version": "==44.0"
         },
-        "refurb": {
-            "hashes": [
-                "sha256:8a8f1e7c131ef7dc460cbecbeaf536f5eb0ecb657c099d7823941f0e65b1cfe1",
-                "sha256:fa9e950dc6edd7473642569c118f8714eefd1e6f21a15ee4210a1be853aaaf80"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==2.0.0"
-        },
         "requests": {
             "hashes": [
                 "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
@@ -1409,14 +1415,6 @@
             ],
             "version": "==75.2.0"
         },
-        "shtab": {
-            "hashes": [
-                "sha256:32d3d2ff9022d4c77a62492b6ec875527883891e33c6b479ba4d41a51e259983",
-                "sha256:4e4bcb02eeb82ec45920a5d0add92eac9c9b63b2804c9196c1f1fdc2d039243c"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.7.1"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -1471,6 +1469,14 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
+        "tomli": {
+            "hashes": [
+                "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38",
+                "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.2"
+        },
         "tomlkit": {
             "hashes": [
                 "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde",
@@ -1513,32 +1519,24 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.11'",
             "version": "==4.12.2"
-        },
-        "tyro": {
-            "hashes": [
-                "sha256:1904bffb0e4d5e16c5eb50c518c89a368a44d56405f79b316c58e1206c102e87",
-                "sha256:2516e34d21763575159459c3b15fe4a13472a2166dff32169c9d7aab70853058"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.8.14"
         },
         "urllib3": {
             "hashes": [
-                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
-                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
+                "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
+                "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.2.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.20"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:2ca56a68ed615b8fe4326d11a0dca5dfbe8fd68510fb6c6349163bed3c15f2b2",
-                "sha256:44a72c29cceb0ee08f300b314848c86e57bf8d1f13107a5e671fb9274138d655"
+                "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba",
+                "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==20.27.0"
+            "version": "==20.27.1"
         },
         "zipp": {
             "hashes": [


### PR DESCRIPTION
In the deployment for v80, I updated the dependencies to be able to publish, as their were known security vulnerabilities in the Django version.
But I did that with Python 3.12, breaking 3.9 and 3.10 support.

Update with Python 3.9.
I doubt we use this project anywhere with 3.9 or even 3.10.
