### PR TITLE
Allow FeatureFlags to be more resource-efficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.admin_views
 
-* [`ManageFeatureFlagsBaseView()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/admin_views.py#L31-L101) - Base admin extra view to manage all existing feature flags in admin.
+* [`ManageFeatureFlagsBaseView()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/admin_views.py#L31-L105) - Base admin extra view to manage all existing feature flags in admin.
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L18-L176) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L21-L205) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 

--- a/bx_django_utils/feature_flags/README.md
+++ b/bx_django_utils/feature_flags/README.md
@@ -72,5 +72,7 @@ class ManageFeatureFlagsAdminExtraView(ManageFeatureFlagsBaseView):
     pass
 ```
 
+## Performance considerations
 
-
+By default, each time the flags state is evaluated (e.g. when calling `foo_feature_flag.is_enabled()`), the flag state is fetched from the underlying storage. This may cause poor performance in hot code paths.
+You can limit this evaluation to once per n seconds by passing the `cache_duration=timedelta(seconds=n)` argument to the `FeatureFlag` constructor.

--- a/bx_django_utils/feature_flags/admin_views.py
+++ b/bx_django_utils/feature_flags/admin_views.py
@@ -84,6 +84,10 @@ class ManageFeatureFlagsBaseView(AdminExtraViewMixin, FormView):
             feature_flag.set_state(new_state)
             change_message = f'Set "{feature_flag.human_name}" to {feature_flag.state.name}'
 
+            if hasattr(feature_flag, '_cache_duration'):
+                eta = int(feature_flag._cache_duration.total_seconds())
+                change_message += f' (will take up to {eta} seconds to take full effect)'
+
             # Create a LogEntry for this action:
             content_type_id = ContentType.objects.get_for_model(FeatureFlagModel).id
             log_entry = LogEntry.objects.log_action(


### PR DESCRIPTION
By default, each time the flags state is evaluated (e.g. when calling `foo_feature_flag.is_enabled()`), the flag state is fetched from the underlying storage. This may cause poor performance in hot code paths.

Add optional, in-process caching capabilities to FeatureFlag by limiting evaluation of its state to once every n seconds.