### PR TITLE
Compatibility with Django 5.1 and Python 3.13

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,8 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.11", "3.10"]
-        django-version: ["5.0", "4.2"]
+        python-version: ["3.13", "3.12", "3.11", "3.10"]
+        django-version: ["5.1", "5.0", "4.2"]
+        exclude:
+          - python-version: "3.13"
+            django-version: "4.2"
+          - python-version: "3.13"
+            django-version: "5.0"
     steps:
     - name: Checkout
       run: |

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Activate "ExtraViewAdminSite" by set this as default admin site
 
 #### bx_django_utils.admin_extra_views.datatypes
 
-* [`AdminExtraMeta()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/datatypes.py#L15-L58) - Stores information for pseudo app and pseudo models.
-* [`PseudoApp()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/datatypes.py#L61-L91) - Represents information about a Django App. Instance must be pass to @register_admin_view()
+* [`AdminExtraMeta()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/datatypes.py#L14-L57) - Stores information for pseudo app and pseudo models.
+* [`PseudoApp()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/datatypes.py#L60-L90) - Represents information about a Django App. Instance must be pass to @register_admin_view()
 
 ###### bx_django_utils.admin_extra_views.management.commands.admin_extra_views
 
@@ -58,8 +58,8 @@ Activate "ExtraViewAdminSite" by set this as default admin site
 
 #### bx_django_utils.admin_extra_views.registry
 
-* [`AdminExtraViewRegistry()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/registry.py#L12-L101) - Hold all information about all admin extra views to expand urls and admin app list.
-* [`register_admin_view()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/registry.py#L107-L120) - Decorator to add a normal view as pseudo App/Model to the admin.
+* [`AdminExtraViewRegistry()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/registry.py#L11-L100) - Hold all information about all admin extra views to expand urls and admin app list.
+* [`register_admin_view()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_extra_views/registry.py#L106-L119) - Decorator to add a normal view as pseudo App/Model to the admin.
 
 #### bx_django_utils.admin_extra_views.site
 
@@ -82,11 +82,11 @@ Activate "ExtraViewAdminSite" by set this as default admin site
 
 Helpers to build Admin URLs
 
-* [`admin_change_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L62-L78) - Shortcut to generate Django admin "change" url for a model instance.
-* [`admin_changelist_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L119-L134) - Shortcut to generate Django admin "changelist" url for a model or instance.
-* [`admin_delete_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L100-L116) - Shortcut to generate Django admin "delete" url for a model instance.
-* [`admin_history_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L81-L97) - Shortcut to generate Django admin "history" url for a model instance.
-* [`admin_model_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L15-L59) - Build Admin change, add, changelist, etc. links with optional filter parameters.
+* [`admin_change_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L61-L77) - Shortcut to generate Django admin "change" url for a model instance.
+* [`admin_changelist_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L118-L133) - Shortcut to generate Django admin "changelist" url for a model or instance.
+* [`admin_delete_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L99-L115) - Shortcut to generate Django admin "delete" url for a model instance.
+* [`admin_history_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L80-L96) - Shortcut to generate Django admin "history" url for a model instance.
+* [`admin_model_url()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/admin_urls.py#L14-L58) - Build Admin change, add, changelist, etc. links with optional filter parameters.
 
 #### bx_django_utils.admin_utils.filters
 
@@ -152,7 +152,7 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L21-L205) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L20-L204) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 
@@ -216,8 +216,8 @@ Utilities to manipulate objects in database via models:
 
 #### bx_django_utils.models.queryset_utils
 
-* [`remove_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L8-L38) - Remove an applied .filter() from a QuerySet
-* [`remove_model_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L41-L68) - Remove an applied .filter() from a QuerySet if it contains references to the specified model
+* [`remove_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L7-L37) - Remove an applied .filter() from a QuerySet
+* [`remove_model_filter()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/models/queryset_utils.py#L40-L67) - Remove an applied .filter() from a QuerySet if it contains references to the specified model
 
 #### bx_django_utils.models.timetracking
 
@@ -244,7 +244,7 @@ Utilities / helper for writing tests.
 
 #### bx_django_utils.test_utils.assert_queries
 
-* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L35-L288) - Assert executed database queries: Check table names, duplicate/similar Queries.
+* [`AssertQueries()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/test_utils/assert_queries.py#L34-L287) - Assert executed database queries: Check table names, duplicate/similar Queries.
 
 #### bx_django_utils.test_utils.cache
 

--- a/bx_django_utils/admin_extra_views/datatypes.py
+++ b/bx_django_utils/admin_extra_views/datatypes.py
@@ -1,12 +1,11 @@
 import dataclasses
-from typing import Callable, List, Set
+from collections.abc import Callable
 
 from django.contrib.admin import AdminSite
 from django.contrib.admin.sites import site as default_site
 from django.utils.text import slugify
 
 from bx_django_utils.admin_extra_views.conditions import only_staff_user
-
 
 _APP_LABELS = set()
 _URL_NAMES = set()
@@ -22,7 +21,7 @@ class AdminExtraMeta:
     app_label: str = None  # Optional: Will be set from name, if not defined
 
     # must all be met to display. If not set: only_staff_user() will be added:
-    conditions: Set[Callable] = dataclasses.field(default_factory=set)
+    conditions: set[Callable] = dataclasses.field(default_factory=set)
 
     # Set via set_url_info():
     url: str = None
@@ -67,7 +66,7 @@ class PseudoApp:
     meta: AdminExtraMeta = None
 
     # Will be filled by @register_admin_view():
-    views: List = dataclasses.field(default_factory=list)
+    views: list = dataclasses.field(default_factory=list)
 
     # The Django Admin site for this extra views (optional):
     admin_site: AdminSite = None

--- a/bx_django_utils/admin_extra_views/registry.py
+++ b/bx_django_utils/admin_extra_views/registry.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator
-from typing import Union
 
 from django.http import HttpRequest
 from django.urls import path, reverse
@@ -17,7 +16,7 @@ class AdminExtraViewRegistry:
     def __init__(self):
         self.pseudo_apps = set()
 
-    def add_view(self, pseudo_app: PseudoApp, view_class: type[Union[AdminExtraViewMixin, View]]) -> None:
+    def add_view(self, pseudo_app: PseudoApp, view_class: type[AdminExtraViewMixin | View]) -> None:
         """
         Collect all admin extra views. Called by our @register_admin_view() decorator.
         """
@@ -93,7 +92,7 @@ class AdminExtraViewRegistry:
 
         return app_list
 
-    def __iter__(self) -> Iterator[type[Union[AdminExtraViewMixin, View]]]:
+    def __iter__(self) -> Iterator[type[AdminExtraViewMixin | View]]:
         """
         Iterate sorted over all registered admin extra view classes.
         """

--- a/bx_django_utils/admin_extra_views/utils.py
+++ b/bx_django_utils/admin_extra_views/utils.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 
 from django.urls import reverse
 

--- a/bx_django_utils/admin_utils/admin_urls.py
+++ b/bx_django_utils/admin_utils/admin_urls.py
@@ -1,7 +1,6 @@
 """
     Helpers to build Admin URLs
 """
-from typing import Optional, Union
 from urllib.parse import urlencode
 
 from django.contrib.admin.utils import quote
@@ -14,11 +13,11 @@ ADMIN_LINK_TYPES = ('changelist', 'add', 'history', 'delete', 'change')
 
 def admin_model_url(
     *,
-    model_or_instance: Union[models.Model, type[models.Model]],
-    action: Optional[str] = None,  # Default is 'changelist' and 'change'
+    model_or_instance: models.Model | type[models.Model],
+    action: str | None = None,  # Default is 'changelist' and 'change'
     admin_prefix: str = 'admin',
-    current_app: Optional[str] = None,
-    params: Optional[dict] = None,
+    current_app: str | None = None,
+    params: dict | None = None,
 ):
     """
     Build Admin change, add, changelist, etc. links with optional filter parameters.
@@ -62,8 +61,8 @@ def admin_model_url(
 def admin_change_url(
     instance: models.Model,
     admin_prefix: str = 'admin',
-    current_app: Optional[str] = None,
-    params: Optional[dict] = None,
+    current_app: str | None = None,
+    params: dict | None = None,
 ):
     """
     Shortcut to generate Django admin "change" url for a model instance.
@@ -81,8 +80,8 @@ def admin_change_url(
 def admin_history_url(
     instance: models.Model,
     admin_prefix: str = 'admin',
-    current_app: Optional[str] = None,
-    params: Optional[dict] = None,
+    current_app: str | None = None,
+    params: dict | None = None,
 ):
     """
     Shortcut to generate Django admin "history" url for a model instance.
@@ -100,8 +99,8 @@ def admin_history_url(
 def admin_delete_url(
     instance: models.Model,
     admin_prefix: str = 'admin',
-    current_app: Optional[str] = None,
-    params: Optional[dict] = None,
+    current_app: str | None = None,
+    params: dict | None = None,
 ):
     """
     Shortcut to generate Django admin "delete" url for a model instance.
@@ -117,10 +116,10 @@ def admin_delete_url(
 
 
 def admin_changelist_url(
-    model_or_instance: Union[models.Model, type[models.Model]],
+    model_or_instance: models.Model | type[models.Model],
     admin_prefix: str = 'admin',
-    current_app: Optional[str] = None,
-    params: Optional[dict] = None,
+    current_app: str | None = None,
+    params: dict | None = None,
 ):
     """
     Shortcut to generate Django admin "changelist" url for a model or instance.

--- a/bx_django_utils/dbperf/query_recorder.py
+++ b/bx_django_utils/dbperf/query_recorder.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
+from collections.abc import Callable
 from pprint import saferepr
-from typing import Callable, Optional
 
 from django.db import connections
 
@@ -112,8 +112,8 @@ class SQLQueryRecorder:
 
     def __init__(
         self,
-        databases: Optional[list[str]] = None,
-        collect_stacktrace: Optional[Callable] = None,
+        databases: list[str] | None = None,
+        collect_stacktrace: Callable | None = None,
         query_explain: bool = False,  # Capture EXPLAIN SQL information?
     ):
         self.logger = Logger()

--- a/bx_django_utils/feature_flags/data_classes.py
+++ b/bx_django_utils/feature_flags/data_classes.py
@@ -1,9 +1,8 @@
 import datetime
 import logging
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
-from typing import Callable, Optional
 
 from django.core.cache import cache
 
@@ -31,7 +30,7 @@ class FeatureFlag:
         cache_key: str,
         human_name: str,
         initial_enabled: bool,
-        description: Optional[str] = None,
+        description: str | None = None,
         cache_key_prefix: str = 'feature-flags',
         cache_duration: datetime.timedelta = DEFAULT_DURATION,
     ):

--- a/bx_django_utils/json_utils.py
+++ b/bx_django_utils/json_utils.py
@@ -1,11 +1,11 @@
 import datetime
 import decimal
 import uuid
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.functional import Promise
-
 
 DJANGO_JSON_ENCODER_TYPES = (  # All types that DjangoJSONEncoder will convert
     datetime.datetime, datetime.date, datetime.time, datetime.timedelta,

--- a/bx_django_utils/models/manipulate.py
+++ b/bx_django_utils/models/manipulate.py
@@ -5,12 +5,12 @@
 """
 import dataclasses
 import warnings
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 from uuid import UUID
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
-
 
 STORE_BEHAVIOR_IGNORE = "i"  # Ignore the value completely
 STORE_BEHAVIOR_SET_IF_EMPTY = "e"  # Use the value only if we currently have no one.
@@ -101,8 +101,8 @@ def create_or_update2(
     lookup: dict = None,
     call_full_clean: bool = True,
     validate_unique: bool = False,
-    store_behavior: Optional[dict] = None,
-    save_kwargs: Optional[dict] = None,
+    store_behavior: dict | None = None,
+    save_kwargs: dict | None = None,
     update_model_field_callback: Callable = update_model_field,
     **values,
 ) -> CreateOrUpdateResult:

--- a/bx_django_utils/models/queryset_utils.py
+++ b/bx_django_utils/models/queryset_utils.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from typing import Type
 
 from django.db.models import Model, Q, QuerySet
 from django.db.models.sql.where import NothingNode
@@ -38,7 +37,7 @@ def remove_filter(queryset: QuerySet, lookup: str) -> QuerySet:
     return queryset
 
 
-def remove_model_filter(queryset: QuerySet, model: Type[Model]) -> QuerySet:
+def remove_model_filter(queryset: QuerySet, model: type[Model]) -> QuerySet:
     """
     Remove an applied .filter() from a QuerySet if it contains references to the specified model
     """

--- a/bx_django_utils/test_utils/assert_queries.py
+++ b/bx_django_utils/test_utils/assert_queries.py
@@ -4,7 +4,6 @@ from collections import Counter
 from difflib import unified_diff
 from pathlib import Path
 from pprint import pformat
-from typing import Optional, Union
 
 from bx_py_utils.test_utils.snapshot import assert_snapshot
 
@@ -176,7 +175,7 @@ class AssertQueries(SQLQueryRecorder):
             ))
             raise AssertionError(self.build_error_message(f'Table names does not match:\n{diff}'))
 
-    def assert_table_counts(self, table_counts: Union[Counter, dict], exclude: Optional[tuple[str, ...]] = None):
+    def assert_table_counts(self, table_counts: Counter | dict, exclude: tuple[str, ...] | None = None):
         if not isinstance(table_counts, Counter):
             table_counts = Counter(table_counts)
         table_name_count = self.count_table_names()
@@ -200,7 +199,7 @@ class AssertQueries(SQLQueryRecorder):
 
             raise AssertionError(self.build_error_message(msg))
 
-    def snapshot_table_counts(self, *, exclude: Optional[tuple[str]] = None, **kwargs):
+    def snapshot_table_counts(self, *, exclude: tuple[str] | None = None, **kwargs):
         table_name_count = self.count_table_names()
         if exclude:
             for k in exclude:
@@ -262,12 +261,12 @@ class AssertQueries(SQLQueryRecorder):
 
     def assert_queries(
         self,
-        table_counts: Optional[Union[Counter, dict]] = None,
-        double_tables: Optional[bool] = True,
-        table_names: Optional[list[str]] = None,
-        query_count: Optional[int] = None,
-        duplicated: Optional[bool] = True,
-        similar: Optional[bool] = True,
+        table_counts: Counter | dict | None = None,
+        double_tables: bool | None = True,
+        table_names: list[str] | None = None,
+        query_count: int | None = None,
+        duplicated: bool | None = True,
+        similar: bool | None = True,
     ):
         """
         Shortcut to assert everything

--- a/bx_django_utils/version.py
+++ b/bx_django_utils/version.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 VERSION_FILE = pathlib.Path(settings.BASE_DIR) / 'VERSION'
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_version(raise_error=False):
     try:
         version_text = VERSION_FILE.read_text()

--- a/bx_django_utils_tests/test_app/tests/test_fixtures_helper.py
+++ b/bx_django_utils_tests/test_app/tests/test_fixtures_helper.py
@@ -1,6 +1,5 @@
 import tempfile
 from pathlib import Path
-from typing import Union
 from unittest.mock import patch
 
 from bx_py_utils.test_utils.redirect import RedirectOut
@@ -178,7 +177,7 @@ class RenewAllFixturesBaseCommandTestCase(SimpleTestCase):
         self,
         *,
         options=None,
-        expected_stdout: Union[str, list[str]],
+        expected_stdout: str | list[str],
         expected_stderr='',
         strip_output=True,
         input=None,

--- a/bx_django_utils_tests/test_project/settings.py
+++ b/bx_django_utils_tests/test_project/settings.py
@@ -110,7 +110,6 @@ AUTH_PASSWORD_VALIDATORS = []  # Just a test project, so no restrictions
 
 LANGUAGE_CODE = 'en-us'
 USE_I18N = True
-USE_L10N = True
 LOCALE_PATHS = (
     BASE_DIR.parent / 'bx_django_utils' / 'locale',
 )

--- a/bx_django_utils_tests/tests/admin_utils/test_filters.py
+++ b/bx_django_utils_tests/tests/admin_utils/test_filters.py
@@ -1,4 +1,3 @@
-import django
 from django.test import TestCase
 from model_bakery import baker
 
@@ -41,26 +40,15 @@ class NotAllSimpleListFilterTestCase(HtmlAssertionMixin, TestCase):
         # without filter -> default
 
         response = self.client.get('/admin/test_app/createorupdatetestmodel/')
-        if django.VERSION >= (4, 1):
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<summary>By blank_field set</summary>',
-                    '<li><a href="?blank_field=all">All</a></li>',
-                    '<li class="selected"><a href="?">Yes</a></li>',  # Yes is default!
-                    '<li><a href="?blank_field=no">No</a></li>',
-                ),
-            )
-        else:
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<h3>By blank_field set</h3>',
-                    '<li><a href="?blank_field=all" title="All">All</a></li>',
-                    '<li class="selected"><a href="?" title="Yes">Yes</a></li>',  # Yes is default!
-                    '<li><a href="?blank_field=no" title="No">No</a></li>',
-                ),
-            )
+        self.assert_html_parts(
+            response,
+            parts=(
+                '<summary>By blank_field set</summary>',
+                '<li><a href="?blank_field=all">All</a></li>',
+                '<li class="selected"><a href="?">Yes</a></li>',  # Yes is default!
+                '<li><a href="?blank_field=no">No</a></li>',
+            ),
+        )
         # Only "filled" item?
         items = self._get_changelist_items(response)
         self.assertEqual(
@@ -75,26 +63,15 @@ class NotAllSimpleListFilterTestCase(HtmlAssertionMixin, TestCase):
         # only blank fields
 
         response = self.client.get('/admin/test_app/createorupdatetestmodel/?blank_field=no')
-        if django.VERSION >= (4, 1):
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<summary>By blank_field set</summary>',
-                    '<li><a href="?blank_field=all">All</a></li>',
-                    '<li><a href="?">Yes</a></li>',  # Yes is default!
-                    '<li class="selected"><a href="?blank_field=no">No</a></li>',
-                ),
-            )
-        else:
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<h3>By blank_field set</h3>',
-                    '<li><a href="?blank_field=all" title="All">All</a></li>',
-                    '<li><a href="?" title="Yes">Yes</a></li>',
-                    '<li class="selected"><a href="?blank_field=no" title="No">No</a></li>',
-                ),
-            )
+        self.assert_html_parts(
+            response,
+            parts=(
+                '<summary>By blank_field set</summary>',
+                '<li><a href="?blank_field=all">All</a></li>',
+                '<li><a href="?">Yes</a></li>',  # Yes is default!
+                '<li class="selected"><a href="?blank_field=no">No</a></li>',
+            ),
+        )
         # Only "empty" item?
         items = self._get_changelist_items(response)
         self.assertEqual(
@@ -110,26 +87,15 @@ class NotAllSimpleListFilterTestCase(HtmlAssertionMixin, TestCase):
         # all entries
 
         response = self.client.get('/admin/test_app/createorupdatetestmodel/?blank_field=all')
-        if django.VERSION >= (4, 1):
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<summary>By blank_field set</summary>',
-                    '<li class="selected"><a href="?blank_field=all">All</a></li>',
-                    '<li><a href="?">Yes</a></li>',  # Yes is default!
-                    '<li><a href="?blank_field=no">No</a></li>',
-                ),
-            )
-        else:
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<h3>By blank_field set</h3>',
-                    '<li class="selected"><a href="?blank_field=all" title="All">All</a></li>',
-                    '<li><a href="?" title="Yes">Yes</a></li>',
-                    '<li><a href="?blank_field=no" title="No">No</a></li>',
-                ),
-            )
+        self.assert_html_parts(
+            response,
+            parts=(
+                '<summary>By blank_field set</summary>',
+                '<li class="selected"><a href="?blank_field=all">All</a></li>',
+                '<li><a href="?">Yes</a></li>',  # Yes is default!
+                '<li><a href="?blank_field=no">No</a></li>',
+            ),
+        )
         # Both: "filled" and "empty" items?
         items = self._get_changelist_items(response)
         self.assertEqual(
@@ -181,35 +147,19 @@ class ExistingCountedListFilterTestCase(HtmlAssertionMixin, TestCase):
         self.client.force_login(self.superuser)
 
         response = self.client.get('/admin/test_app/createorupdatetestmodel/')
-        if django.VERSION >= (4, 1):
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<summary>By name</summary>',
-                    (
-                        '<li>'
-                        '<a href="?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E">'
-                        '&lt;foo&gt; / &lt;bar&gt; (1)</a>'
-                        '</li>'
-                    ),
-                    '<li><a href="?name=Foo">Foo (2)</a></li>',
+        self.assert_html_parts(
+            response,
+            parts=(
+                '<summary>By name</summary>',
+                (
+                    '<li>'
+                    '<a href="?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E">'
+                    '&lt;foo&gt; / &lt;bar&gt; (1)</a>'
+                    '</li>'
                 ),
-            )
-        else:
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<h3>By name</h3>',
-                    (
-                        '<li>'
-                        '<a href="?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E"'
-                        ' title="&lt;foo&gt; / &lt;bar&gt; (1)">'
-                        '&lt;foo&gt; / &lt;bar&gt; (1)'
-                        '</a></li>'
-                    ),
-                    '<li><a href="?name=Foo" title="Foo (2)">Foo (2)</a></li>',
-                ),
-            )
+                '<li><a href="?name=Foo">Foo (2)</a></li>',
+            ),
+        )
         items = self._get_changelist_items(response)
         self.assertEqual(
             items,
@@ -237,35 +187,19 @@ class ExistingCountedListFilterTestCase(HtmlAssertionMixin, TestCase):
         response = self.client.get(
             '/admin/test_app/createorupdatetestmodel/?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E'
         )
-        if django.VERSION >= (4, 1):
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<summary>By name</summary>',
-                    (
-                        '<li class="selected">'
-                        '<a href="?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E">'
-                        '&lt;foo&gt; / &lt;bar&gt; (1)</a>'
-                        '</li>'
-                    ),
-                    '<li><a href="?name=Foo">Foo (2)</a></li>',
+        self.assert_html_parts(
+            response,
+            parts=(
+                '<summary>By name</summary>',
+                (
+                    '<li class="selected">'
+                    '<a href="?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E">'
+                    '&lt;foo&gt; / &lt;bar&gt; (1)</a>'
+                    '</li>'
                 ),
-            )
-        else:
-            self.assert_html_parts(
-                response,
-                parts=(
-                    '<h3>By name</h3>',
-                    (
-                        '<li class="selected">'
-                        '<a href="?name=%253Cfoo%253E%2B%252F%2B%253Cbar%253E"'
-                        ' title="&lt;foo&gt; / &lt;bar&gt; (1)">'
-                        '&lt;foo&gt; / &lt;bar&gt; (1)'
-                        '</a></li>'
-                    ),
-                    '<li><a href="?name=Foo" title="Foo (2)">Foo (2)</a></li>',
-                ),
-            )
+                '<li><a href="?name=Foo">Foo (2)</a></li>',
+            ),
+        )
         items = self._get_changelist_items(response)
         self.assertEqual(
             items,

--- a/bx_django_utils_tests/tests/test_admin_extra_views_index_page_django51_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_admin_extra_views_index_page_django51_1.snapshot.html
@@ -1,0 +1,311 @@
+<div id="content-main">
+ <div class="app-admin module">
+  <table>
+   <caption>
+    <a class="section" href="/admin/admin/" title="Models in the Administration application">
+     Administration
+    </a>
+   </caption>
+   <tr class="model-logentry">
+    <th id="admin-logentry" scope="row">
+     <a href="/admin/admin/logentry/">
+      Log entries
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="admin-logentry" class="addlink" href="/admin/admin/logentry/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="admin-logentry" class="changelink" href="/admin/admin/logentry/">
+      Change
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-approve_workflow_test_app module">
+  <table>
+   <caption>
+    <a class="section" href="/admin/approve_workflow_test_app/" title="Models in the Approve_Workflow_Test_App application">
+     Approve_Workflow_Test_App
+    </a>
+   </caption>
+   <tr class="model-approvetestmodel">
+    <th id="approve_workflow_test_app-approvetestmodel" scope="row">
+     <a href="/admin/approve_workflow_test_app/approvetestmodel/">
+      Approve test models
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="approve_workflow_test_app-approvetestmodel" class="addlink" href="/admin/approve_workflow_test_app/approvetestmodel/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="approve_workflow_test_app-approvetestmodel" class="changelink" href="/admin/approve_workflow_test_app/approvetestmodel/">
+      Change
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-auth module">
+  <table>
+   <caption>
+    <a class="section" href="/admin/auth/" title="Models in the Authentication and Authorization application">
+     Authentication and Authorization
+    </a>
+   </caption>
+   <tr class="model-group">
+    <th id="auth-group" scope="row">
+     <a href="/admin/auth/group/">
+      Groups
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="auth-group" class="addlink" href="/admin/auth/group/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="auth-group" class="changelink" href="/admin/auth/group/">
+      Change
+     </a>
+    </td>
+   </tr>
+   <tr class="model-user">
+    <th id="auth-user" scope="row">
+     <a href="/admin/auth/user/">
+      Users
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="auth-user" class="addlink" href="/admin/auth/user/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="auth-user" class="changelink" href="/admin/auth/user/">
+      Change
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-test_app module">
+  <table>
+   <caption>
+    <a class="section" href="/admin/test_app/" title="Models in the Test_App application">
+     Test_App
+    </a>
+   </caption>
+   <tr class="model-colorfieldtestmodel">
+    <th id="test_app-colorfieldtestmodel" scope="row">
+     <a href="/admin/test_app/colorfieldtestmodel/">
+      Color field test models
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="test_app-colorfieldtestmodel" class="addlink" href="/admin/test_app/colorfieldtestmodel/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="test_app-colorfieldtestmodel" class="changelink" href="/admin/test_app/colorfieldtestmodel/">
+      Change
+     </a>
+    </td>
+   </tr>
+   <tr class="model-createorupdatetestmodel">
+    <th id="test_app-createorupdatetestmodel" scope="row">
+     <a href="/admin/test_app/createorupdatetestmodel/">
+      Create or update test models
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="test_app-createorupdatetestmodel" class="addlink" href="/admin/test_app/createorupdatetestmodel/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="test_app-createorupdatetestmodel" class="changelink" href="/admin/test_app/createorupdatetestmodel/">
+      Change
+     </a>
+    </td>
+   </tr>
+   <tr class="model-translatedmodel">
+    <th id="test_app-translatedmodel" scope="row">
+     <a href="/admin/test_app/translatedmodel/">
+      Translated models
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="test_app-translatedmodel" class="addlink" href="/admin/test_app/translatedmodel/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="test_app-translatedmodel" class="changelink" href="/admin/test_app/translatedmodel/">
+      Change
+     </a>
+    </td>
+   </tr>
+   <tr class="model-translatedslugtestmodel">
+    <th id="test_app-translatedslugtestmodel" scope="row">
+     <a href="/admin/test_app/translatedslugtestmodel/">
+      Translated slug test models
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="test_app-translatedslugtestmodel" class="addlink" href="/admin/test_app/translatedslugtestmodel/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="test_app-translatedslugtestmodel" class="changelink" href="/admin/test_app/translatedslugtestmodel/">
+      Change
+     </a>
+    </td>
+   </tr>
+   <tr class="model-validatelengthtranslations">
+    <th id="test_app-validatelengthtranslations" scope="row">
+     <a href="/admin/test_app/validatelengthtranslations/">
+      Validate length translationss
+     </a>
+    </th>
+    <td>
+     <a aria-describedby="test_app-validatelengthtranslations" class="addlink" href="/admin/test_app/validatelengthtranslations/add/">
+      Add
+     </a>
+    </td>
+    <td>
+     <a aria-describedby="test_app-validatelengthtranslations" class="changelink" href="/admin/test_app/validatelengthtranslations/">
+      Change
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-feature_flags module">
+  <table>
+   <caption>
+    <a class="section" href="" title="Models in the Feature Flags application">
+     Feature Flags
+    </a>
+   </caption>
+   <tr class="model-">
+    <th id="feature_flags-" scope="row">
+     <a href="/admin/feature_flags/feature-flags-values-demo/">
+      Feature Flags values DEMO
+     </a>
+    </th>
+    <td>
+    </td>
+    <td>
+     <a aria-describedby="feature_flags-" class="viewlink" href="/admin/feature_flags/feature-flags-values-demo/">
+      View
+     </a>
+    </td>
+   </tr>
+   <tr class="model-">
+    <th id="feature_flags-" scope="row">
+     <a href="/admin/feature_flags/manage/">
+      Manage Feature Flags
+     </a>
+    </th>
+    <td>
+    </td>
+    <td>
+     <a aria-describedby="feature_flags-" class="viewlink" href="/admin/feature_flags/manage/">
+      View
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-generic-model-filter module">
+  <table>
+   <caption>
+    <a class="section" href="" title="Models in the Generic Model Filter application">
+     Generic Model Filter
+    </a>
+   </caption>
+   <tr class="model-">
+    <th id="generic-model-filter-" scope="row">
+     <a href="/admin/generic-model-filter/generic-filter/">
+      Generic model item filter
+     </a>
+    </th>
+    <td>
+    </td>
+    <td>
+     <a aria-describedby="generic-model-filter-" class="viewlink" href="/admin/generic-model-filter/generic-filter/">
+      View
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-pseudo-app-1 module">
+  <table>
+   <caption>
+    <a class="section" href="" title="Models in the Pseudo App 1 application">
+     Pseudo App 1
+    </a>
+   </caption>
+   <tr class="model-">
+    <th id="pseudo-app-1-" scope="row">
+     <a href="/admin/pseudo-app-1/demo-view-1/">
+      Demo View 1
+     </a>
+    </th>
+    <td>
+    </td>
+    <td>
+     <a aria-describedby="pseudo-app-1-" class="viewlink" href="/admin/pseudo-app-1/demo-view-1/">
+      View
+     </a>
+    </td>
+   </tr>
+   <tr class="model-">
+    <th id="pseudo-app-1-" scope="row">
+     <a href="/admin/pseudo-app-1/demo-view-2/">
+      Demo View 2
+     </a>
+    </th>
+    <td>
+    </td>
+    <td>
+     <a aria-describedby="pseudo-app-1-" class="viewlink" href="/admin/pseudo-app-1/demo-view-2/">
+      View
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+ <div class="app-pseudo-app-2 module">
+  <table>
+   <caption>
+    <a class="section" href="" title="Models in the Pseudo App 2 application">
+     Pseudo App 2
+    </a>
+   </caption>
+   <tr class="model-">
+    <th id="pseudo-app-2-" scope="row">
+     <a href="/admin/pseudo-app-2/demo-view-3/">
+      Demo View 3
+     </a>
+    </th>
+    <td>
+    </td>
+    <td>
+     <a aria-describedby="pseudo-app-2-" class="viewlink" href="/admin/pseudo-app-2/demo-view-3/">
+      View
+     </a>
+    </td>
+   </tr>
+  </table>
+ </div>
+</div>

--- a/bx_django_utils_tests/tests/test_feature_flag_integration_basic_django51_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_feature_flag_integration_basic_django51_1.snapshot.html
@@ -1,0 +1,48 @@
+<div class="colM" id="content">
+ <h2 id="foo">
+  Foo - ENABLED
+  <a href="#foo">
+   ¶
+  </a>
+ </h2>
+ <pre>En-/disable example Feature flag `Foo`.
+Just for demonstrate.</pre>
+ <p>
+  (Initial default state: ENABLED)
+ </p>
+ <p>
+  Current state:
+  <strong>
+   ENABLED
+  </strong>
+ </p>
+ <form method="post">
+  MockedCsrfTokenNode
+  <input name="cache_key" type="hidden" value="feature-flags-foo"/>
+  <input name="new_value" type="hidden" value="0"/>
+  <input type="submit" value="Set 'Foo' to DISABLED"/>
+ </form>
+ <h2 id="bar">
+  Bar - DISABLED
+  <a href="#bar">
+   ¶
+  </a>
+ </h2>
+ <pre>En-/disable example Feature flag `Bar`.</pre>
+ <p>
+  (Initial default state: DISABLED)
+ </p>
+ <p>
+  Current state:
+  <strong>
+   DISABLED
+  </strong>
+ </p>
+ <form method="post">
+  MockedCsrfTokenNode
+  <input name="cache_key" type="hidden" value="feature-flags-bar"/>
+  <input name="new_value" type="hidden" value="1"/>
+  <input type="submit" value="Set 'Bar' to ENABLED"/>
+ </form>
+ <br class="clear"/>
+</div>

--- a/bx_django_utils_tests/tests/test_html_assertion_assert_html_response_snapshot_django51_1.snapshot.html
+++ b/bx_django_utils_tests/tests/test_html_assertion_assert_html_response_snapshot_django51_1.snapshot.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en-us">
+ <head>
+  <title>
+   Log in | Django site admin
+  </title>
+  <link href="/static/admin/css/base.css" rel="stylesheet"/>
+  <link href="/static/admin/css/dark_mode.css" rel="stylesheet"/>
+  <script src="/static/admin/js/theme.js">
+  </script>
+  <link href="/static/admin/css/nav_sidebar.css" rel="stylesheet"/>
+  <script defer="" src="/static/admin/js/nav_sidebar.js">
+  </script>
+  <link href="/static/admin/css/login.css" rel="stylesheet"/>
+  <script src="/static/user_timezone.js">
+  </script>
+  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+  <link href="/static/admin/css/responsive.css" rel="stylesheet"/>
+  <meta content="NONE,NOARCHIVE" name="robots"/>
+ </head>
+ <body class="login" data-admin-utc-offset="0">
+  <a class="skip-to-content-link" href="#content-start">
+   Skip to main content
+  </a>
+  <!-- Container -->
+  <div id="container">
+   <!-- Header -->
+   <header id="header">
+    <div id="branding">
+     <div id="site-name">
+      <a href="/admin/">
+       Django administration
+      </a>
+     </div>
+     <button class="theme-toggle">
+      <span class="visually-hidden theme-label-when-auto">
+       Toggle theme (current theme: auto)
+      </span>
+      <span class="visually-hidden theme-label-when-light">
+       Toggle theme (current theme: light)
+      </span>
+      <span class="visually-hidden theme-label-when-dark">
+       Toggle theme (current theme: dark)
+      </span>
+      <svg aria-hidden="true" class="theme-icon-when-auto">
+       <use xlink:href="#icon-auto">
+       </use>
+      </svg>
+      <svg aria-hidden="true" class="theme-icon-when-dark">
+       <use xlink:href="#icon-moon">
+       </use>
+      </svg>
+      <svg aria-hidden="true" class="theme-icon-when-light">
+       <use xlink:href="#icon-sun">
+       </use>
+      </svg>
+     </button>
+    </div>
+   </header>
+   <!-- END Header -->
+   <div class="main" id="main">
+    <main class="content" id="content-start" tabindex="-1">
+     <!-- Content -->
+     <div class="colM" id="content">
+      <div id="content-main">
+       <form action="/admin/login/" id="login-form" method="post">
+        MockedCsrfTokenNode
+        <div class="form-row">
+         <label class="required" for="id_username">
+          Username:
+         </label>
+         <input autocapitalize="none" autocomplete="username" autofocus="" id="id_username" maxlength="150" name="username" required="" type="text"/>
+        </div>
+        <div class="form-row">
+         <label class="required" for="id_password">
+          Password:
+         </label>
+         <input autocomplete="current-password" id="id_password" name="password" required="" type="password"/>
+         <input name="next" type="hidden" value="/admin/"/>
+        </div>
+        <div class="submit-row">
+         <input type="submit" value="Log in"/>
+        </div>
+       </form>
+      </div>
+      <br class="clear"/>
+     </div>
+     <!-- END Content -->
+    </main>
+   </div>
+   <footer id="footer">
+   </footer>
+  </div>
+  <!-- END Container -->
+  <!-- SVGs -->
+  <svg class="base-svgs" xmlns="http://www.w3.org/2000/svg">
+   <symbol height="1rem" id="icon-auto" viewbox="0 0 24 24" width="1rem">
+    <path d="M0 0h24v24H0z" fill="currentColor">
+    </path>
+    <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2V4a8 8 0 1 0 0 16z">
+    </path>
+   </symbol>
+   <symbol height="1rem" id="icon-moon" viewbox="0 0 24 24" width="1rem">
+    <path d="M0 0h24v24H0z" fill="currentColor">
+    </path>
+    <path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z">
+    </path>
+   </symbol>
+   <symbol height="1rem" id="icon-sun" viewbox="0 0 24 24" width="1rem">
+    <path d="M0 0h24v24H0z" fill="currentColor">
+    </path>
+    <path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z">
+    </path>
+   </symbol>
+  </svg>
+  <!-- END SVGs -->
+ </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     'Framework :: Django',
     'Intended Audience :: Developers',
 ]
 license = {text = "MIT"}
 readme="README.md"
+requires-python = ">=3.10,<4"
 
 
 dependencies = [
@@ -129,7 +131,8 @@ legacy_tox_ini = """
 [tox]
 isolated_build = True
 envlist =
-    py{310,311,312}-django{42,50}
+    py{310,311,312}-django{42,50,51}
+    py313-django51
 skip_missing_interpreters = True
 
 [testenv]
@@ -138,6 +141,7 @@ deps =
     .[dev]
     django42: django>=4.2,<4.3
     django50: django>=5.0,<5.1
+    django51: django>=5.1,<5.2
 commands_pre =
     {envpython} -m playwright install chromium firefox
 commands =


### PR DESCRIPTION
Also run `pyupgrade --py310-plus` and `django-upgrade --target-version 4.2` against the codebase as those are our minimum supported version.

Add the `requires-python` directive to `pyproject.toml` to properly reflect our minimum Python version.