### PR TITLE
Add retval_factory parameter to @if_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.utils
 
-* [`if_feature()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/utils.py#L20-L38) - A decorator that only executed the decorated function if the given feature flag is enabled.
+* [`if_feature()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/utils.py#L20-L48) - A decorator that only executes the decorated function if the given feature flag is enabled.
 
 ### bx_django_utils.filename
 

--- a/bx_django_utils/feature_flags/tests/test_feature_flags.py
+++ b/bx_django_utils/feature_flags/tests/test_feature_flags.py
@@ -209,6 +209,20 @@ class FeatureFlagsTestCase(FeatureFlagTestCaseMixin, TestCase):
         increment()
         self.assertEqual(some_var, 1)
 
+    def test_decorator_with_retval_factory(self):
+        def default_numbers() -> list[int]:
+            return [97, 98, 99]
+
+        @if_feature(self.initial_enabled_test_flag, retval_factory=default_numbers)
+        def compute_numbers() -> list[int]:
+            return [1, 2, 3]
+
+        self.assertTrue(self.initial_enabled_test_flag)
+        self.assertEqual(compute_numbers(), [1, 2, 3])
+        self.initial_enabled_test_flag.disable()
+        self.assertFalse(self.initial_enabled_test_flag)
+        self.assertEqual(compute_numbers(), [97, 98, 99])
+
     def test_decorator_with_args(self):
         some_var = 0
         call_kwargs = None

--- a/bx_django_utils/feature_flags/utils.py
+++ b/bx_django_utils/feature_flags/utils.py
@@ -1,11 +1,11 @@
 import functools
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from django.core.cache.backends.base import memcache_key_warnings
 from django.core.exceptions import ValidationError
 
 from bx_django_utils.feature_flags.exceptions import FeatureFlagDisabled
-
 
 if TYPE_CHECKING:
     from bx_django_utils.feature_flags.data_classes import FeatureFlag
@@ -17,20 +17,30 @@ def validate_cache_key(cache_key: str) -> None:
         raise ValidationError(messages)
 
 
-def if_feature(feature_flag: "FeatureFlag", raise_exception: bool = False):
+def if_feature(
+    feature_flag: "FeatureFlag",
+    raise_exception: bool = False,
+    retval_factory: Callable[[], Any] | None = None,
+):
     """
-    A decorator that only executed the decorated function if the given feature flag is enabled.
-    Performs a noop otherwise, or raises a FeatureFlagDisabled exception if raise_exception is True.
+    A decorator that only executes the decorated function if the given feature flag is enabled.
+
+    :param feature_flag: The feature flag to consider.
+    :param retval_factory: A factory that returns the value to be returned when the feature flag is disabled.
+    :param raise_exception: If True, raises a FeatureFlagDisabled exception if the feature flag is disabled.
     """
+    if raise_exception and retval_factory is not None:
+        raise ValueError('raise_exception=True and retval_factory are mutually exclusive')
 
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if not feature_flag.is_enabled:
-                if not raise_exception:
-                    return
-                else:
+                if raise_exception:
                     raise FeatureFlagDisabled(feature_flag)
+                if retval_factory is not None:
+                    return retval_factory()
+                return
             return func(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
Currently, if a feature flag is disabled, the @if_enabled decorator will always return `None`. This may break the caller if it expects a return value of the same type as it would receive when the flag is enabled, or make the caller code more verbose because of necessary `None` checks.
Adding the new optional `retval_factory` parameter lets the caller specify which non-`None` value should be returned in that case.

Example where the caller would break:
```
myflag = FeatureFlag(...)

@if_enabled(myflag)
def get_numbers() -> list[int]:
    return [3, 1, 2]

myflag.disable()
the_numbers = get_numbers()
the_numbers.sort()  # AttributeError: 'NoneType' object has no attribute 'sort'
```

With the proposed change this issue can be alleviated by specifying the decorator as `@if_enabled(myflag, retval_factory=list)`.