### PR TITLE
Loose typing of databases argument for SQLQueryRecorder

### DIFF
--- a/bx_django_utils/dbperf/query_recorder.py
+++ b/bx_django_utils/dbperf/query_recorder.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pprint import saferepr
 
 from django.db import connections
@@ -112,7 +112,7 @@ class SQLQueryRecorder:
 
     def __init__(
         self,
-        databases: list[str] | None = None,
+        databases: Iterable[str] | None = None,
         collect_stacktrace: Callable | None = None,
         query_explain: bool = False,  # Capture EXPLAIN SQL information?
     ):


### PR DESCRIPTION
There's no reason to restrict it to lists, any iterable will do. Especially handy for tests since `django.test.testcases.SimpleTestCase.databases` defaults to an empty set.