### PR TITLE
Fix temp_* functions in feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L171) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L173) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 

--- a/bx_django_utils/feature_flags/data_classes.py
+++ b/bx_django_utils/feature_flags/data_classes.py
@@ -115,10 +115,11 @@ class FeatureFlag:
         if not was_enabled:
             self.enable()
 
-        yield
-
-        if not was_enabled:
-            self.disable()
+        try:
+            yield
+        finally:
+            if not was_enabled:
+                self.disable()
 
     @contextmanager
     def temp_disable(self) -> Iterator[None]:
@@ -129,10 +130,11 @@ class FeatureFlag:
         if not was_disabled:
             self.disable()
 
-        yield
-
-        if not was_disabled:
-            self.enable()
+        try:
+            yield
+        finally:
+            if not was_disabled:
+                self.enable()
 
     @property
     def state(self):

--- a/bx_django_utils_tests/tests/test_feature_flag_integration.py
+++ b/bx_django_utils_tests/tests/test_feature_flag_integration.py
@@ -178,12 +178,14 @@ class PersistentFeatureFlagTestCase(FeatureFlagTestCaseMixin, TestCase):
         self.assertTrue(foo_feature_flag)
         self.assertFalse(bar_feature_flag)
 
-        with (
-            foo_feature_flag.temp_enable(),
-            bar_feature_flag.temp_enable(),
-        ):
-            self.assertTrue(foo_feature_flag)
-            self.assertTrue(bar_feature_flag)
+        with self.assertRaises(ZeroDivisionError):
+            with (
+                foo_feature_flag.temp_enable(),
+                bar_feature_flag.temp_enable(),
+            ):
+                self.assertTrue(foo_feature_flag)
+                self.assertTrue(bar_feature_flag)
+                1 / 0
 
         self.assertTrue(foo_feature_flag)
         self.assertFalse(bar_feature_flag)
@@ -192,12 +194,14 @@ class PersistentFeatureFlagTestCase(FeatureFlagTestCaseMixin, TestCase):
         self.assertTrue(foo_feature_flag)
         self.assertFalse(bar_feature_flag)
 
-        with (
-            foo_feature_flag.temp_disable(),
-            bar_feature_flag.temp_disable(),
-        ):
-            self.assertFalse(foo_feature_flag)
-            self.assertFalse(bar_feature_flag)
+        with self.assertRaises(ZeroDivisionError):
+            with (
+                foo_feature_flag.temp_disable(),
+                bar_feature_flag.temp_disable(),
+            ):
+                self.assertFalse(foo_feature_flag)
+                self.assertFalse(bar_feature_flag)
+                1 / 0
 
         self.assertTrue(foo_feature_flag)
         self.assertFalse(bar_feature_flag)


### PR DESCRIPTION
When the body of a context manager defined with `@contextmanager` and the iterator protocol (`yield`) raises an exception, the `yield` will raise!

Make sure we restore the flag to the previous value if that happens.
