### PR TITLE
Feature flags: Update local cache when setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Feature flags: https://github.com/boxine/bx_django_utils/blob/master/bx_django_u
 
 #### bx_django_utils.feature_flags.data_classes
 
-* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L173) - A feature flag that persistent the state into django cache/database.
+* [`FeatureFlag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/feature_flags/data_classes.py#L17-L177) - A feature flag that persistent the state into django cache/database.
 
 #### bx_django_utils.feature_flags.test_utils
 

--- a/bx_django_utils/feature_flags/data_classes.py
+++ b/bx_django_utils/feature_flags/data_classes.py
@@ -73,6 +73,10 @@ class FeatureFlag:
             state=new_state,
         )
 
+        if hasattr(self, '_cache_duration'):
+            self._cache_from = self._cache_time_func()
+            self._cache_value = new_state
+
         return bool(obj.instance.state)
 
     def reset(self) -> None:

--- a/bx_django_utils/feature_flags/tests/test_feature_flags.py
+++ b/bx_django_utils/feature_flags/tests/test_feature_flags.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 
 from django.test import TestCase
@@ -184,7 +185,10 @@ class FeatureFlagsTestCase(FeatureFlagTestCaseMixin, TestCase):
         )
         self.assertTrue(ff)
 
-        ff.disable()
+        # Another process has another reference
+        another_reference = copy.deepcopy(ff)
+        another_reference.disable()
+        self.assertFalse(another_reference)  # updated in that process
         self.assertTrue(ff)  # still enabled due to caching!
 
         orig_time_func = ff._cache_time_func


### PR DESCRIPTION
When a feature flag is changed, immediately querying it should return the value we just set!

Update the locally stored cache value.
