### PR TITLE
Bugfix "make publish"

### DIFF
--- a/bx_django_utils_tests/test_project/publish.py
+++ b/bx_django_utils_tests/test_project/publish.py
@@ -21,7 +21,6 @@ def publish():
     assert_is_file(package_path / 'pyproject.toml')
 
     verbose_check_call('make', 'test')  # don't publish if tests fail
-    verbose_check_call('make', 'fix-code-style')  # don't publish if code style wrong
 
     publish_package(
         module=bx_django_utils,


### PR DESCRIPTION
The `fix-code-style` target was remove and it's not needed, because the test `ProjectSetupTestCase.test_code_style()` will already call `make lint` ;)