### PR TITLE
Truncate object_repr to 200 chars in create_log_entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Helpers to build Admin URLs
 
 Helper functions around Django's admin LogEntry model.
 
-* [`create_log_entry()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L25-L47) - Helper to create `LogEntry` entries for a model instance.
-* [`get_change_message_strings()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L50-L58) - Get `LogEntry` change messages as plain strings build by `LogEntry.get_change_message()`.
-* [`get_log_entry_qs()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L81-L104) - Get a QuerySet of LogEntry objects, with optional filtering by model, object ID, and action flag.
-* [`get_log_message_data()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L61-L78) - Get `LogEntry` change messages data structure as list.
+* [`create_log_entry()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L25-L49) - Helper to create `LogEntry` entries for a model instance.
+* [`get_change_message_strings()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L52-L60) - Get `LogEntry` change messages as plain strings build by `LogEntry.get_change_message()`.
+* [`get_log_entry_qs()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L83-L106) - Get a QuerySet of LogEntry objects, with optional filtering by model, object ID, and action flag.
+* [`get_log_message_data()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L63-L80) - Get `LogEntry` change messages data structure as list.
 * [`validate_action_flag()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/admin_utils/log_entry.py#L17-L22) - Validate that the action flag is one of the allowed values.
 
 ### bx_django_utils.approve_workflow

--- a/bx_django_utils/__init__.py
+++ b/bx_django_utils/__init__.py
@@ -1,2 +1,2 @@
 # See https://packaging.python.org/en/latest/specifications/version-specifiers/
-__version__ = '95'
+__version__ = '96'

--- a/bx_django_utils/admin_utils/log_entry.py
+++ b/bx_django_utils/admin_utils/log_entry.py
@@ -33,12 +33,14 @@ def create_log_entry(
     Helper to create `LogEntry` entries for a model instance.
     Note: `call_full_clean` will result in additional database queries.
     """
+    if isinstance(change_message, list):
+        change_message = json.dumps(change_message)
     content_type = ContentType.objects.get_for_model(instance)
     log_entry = LogEntry(
         user_id=user.id,
         content_type_id=content_type.pk,
         object_id=instance.pk,
-        object_repr=str(instance),
+        object_repr=str(instance)[:200],
         action_flag=action_flag,
         change_message=change_message,
     )

--- a/bx_django_utils/admin_utils/tests/test_log_entry.py
+++ b/bx_django_utils/admin_utils/tests/test_log_entry.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -27,12 +29,15 @@ class LogEntryTestCase(TestCase):
         # Test create_log_entry():
         # Create some log entries with "change_message" values like in the Django admin:
         create_log_entry(user=user1, instance=user2, action_flag=ADDITION, change_message='[{"added": {}}]')
-        create_log_entry(
+        log_entry = create_log_entry(
             user=user1,
             instance=user2,
             action_flag=CHANGE,
-            change_message='[{"changed": {"fields": ["Staff status"]}}]',
+            change_message=[{"changed": {"fields": ["Staff status"]}}],
         )
+        # Lists will be converted to JSON string:
+        self.assertEqual(log_entry.change_message, '[{"changed": {"fields": ["Staff status"]}}]')
+
         create_log_entry(
             user=user1,
             instance=user2,
@@ -128,3 +133,13 @@ class LogEntryTestCase(TestCase):
                 action_flag='Bam!',
                 change_message='foo',
             )
+
+        # object_repr length will be truncated to 200 chars:
+        with patch.object(User, '__str__', return_value='x' * 201):
+            log_entry = create_log_entry(
+                user=user1,
+                instance=user2,
+                action_flag=CHANGE,
+                change_message='test',
+            )
+        self.assertEqual(log_entry.object_repr, 'x' * 200)


### PR DESCRIPTION
`LogEntry.object_repr` has `max_length=200`; without the slice Django's `full_clean()` raises a ValidationError for long instance reprs.

Also ensure the `list → JSON` conversion happens before the LogEntry is built (was placed after in the previous version).