### PR TITLE
fix SQLQueryRecorder cursor restore on __exit__

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ModelField, FormField and validators for GTIN/UPC/EAN numbers
 
 #### bx_django_utils.dbperf.query_recorder
 
-* [`SQLQueryRecorder()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/dbperf/query_recorder.py#L106-L185) - A context manager that allows recording SQL queries executed during its lifetime.
+* [`SQLQueryRecorder()`](https://github.com/boxine/bx_django_utils/blob/master/bx_django_utils/dbperf/query_recorder.py#L119-L201) - A context manager that allows recording SQL queries executed during its lifetime.
 
 ### bx_django_utils.feature_flags
 

--- a/bx_django_utils/__init__.py
+++ b/bx_django_utils/__init__.py
@@ -1,2 +1,2 @@
 # See https://packaging.python.org/en/latest/specifications/version-specifiers/
-__version__ = '98'
+__version__ = '99'

--- a/bx_django_utils/dbperf/query_recorder.py
+++ b/bx_django_utils/dbperf/query_recorder.py
@@ -103,6 +103,19 @@ def _get_cursor_wrapper(*, cursor, connection, logger, collect_stacktrace, query
     )
 
 
+def _restore_cursor(connection, attr, saved):
+    """
+    Restore a cursor attribute saved before wrapping. If the saved value is the
+    class-level method (bound or unbound), remove our instance attribute so the
+    class method becomes visible again; otherwise reinstate the saved value.
+    """
+    cls_method = getattr(type(connection), attr)
+    if getattr(saved, '__func__', None) is cls_method or saved is cls_method:
+        delattr(connection, attr)
+    else:
+        setattr(connection, attr, saved)
+
+
 class SQLQueryRecorder:
     """
     A context manager that allows recording SQL queries executed during its lifetime.
@@ -150,18 +163,18 @@ class SQLQueryRecorder:
                 'connection': connection,
                 'logger': self.logger,
                 'collect_stacktrace': self.collect_stacktrace,
-                'query_explain': self.query_explain
+                'query_explain': self.query_explain,
             }
 
             connection.cursor = partial(
                 _get_cursor_wrapper,
                 cursor=connection._recording_cursor,
-                **common_kwargs
+                **common_kwargs,
             )
             connection.chunked_cursor = partial(
                 _get_cursor_wrapper,
                 cursor=connection._recording_chunked_cursor,
-                **common_kwargs
+                **common_kwargs,
             )
 
         self.running = True
@@ -169,14 +182,17 @@ class SQLQueryRecorder:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for connection in self.databases:
-            assert hasattr(connection, '_recording_cursor'), \
+            assert hasattr(connection, '_recording_cursor'), (
                 'the connection has already been unwrapped, this should not have happened'
+            )
 
-            # undo the cursor wrapping so the connection is 'clean' again
+            saved_cursor = connection._recording_cursor
+            saved_chunked_cursor = connection._recording_chunked_cursor
             del connection._recording_cursor
             del connection._recording_chunked_cursor
-            del connection.cursor
-            del connection.chunked_cursor
+
+            _restore_cursor(connection, 'cursor', saved_cursor)
+            _restore_cursor(connection, 'chunked_cursor', saved_chunked_cursor)
 
         self.running = False
 

--- a/bx_django_utils_tests/tests/test_dbperf.py
+++ b/bx_django_utils_tests/tests/test_dbperf.py
@@ -1,3 +1,6 @@
+from functools import partial
+from unittest.mock import sentinel
+
 from django.db import connections
 from django.db.backends.utils import CursorWrapper
 from django.test import TestCase
@@ -95,3 +98,44 @@ class SQLQueryRecorderTestCase(TestCase):
         self.assertEqual(res['queries_duplicated']['default'][(query, "('foo',)")], 2)
         self.assertNotIn((query, "('bar',)"), res['queries_duplicated']['default'])
         self.assertNotIn((query, "('baz',)"), res['queries_duplicated']['default'])
+
+    def test_exit_restores_preexisting_cursor_instance_attr(self):
+        # If something else (e.g. Django's _DatabaseFailure) set cursor as an
+        # instance attribute before we entered, __exit__ must restore that value
+        # instead of deleting the attribute entirely.
+        conn = connections['default']
+        fake_cursor = partial(lambda: sentinel.cursor)
+        conn.cursor = fake_cursor
+
+        try:
+            with SQLQueryRecorder(databases=['default']):
+                # Inside the context the cursor is wrapped
+                self.assertNotEqual(conn.cursor, fake_cursor)
+
+            # After exit, the pre-existing instance attribute is restored
+            self.assertIs(conn.cursor, fake_cursor)
+        finally:
+            del conn.cursor  # clean up so other tests see the class-level method
+
+    def test_exit_removes_instance_attr_when_class_method_was_original(self):
+        # If no instance-level cursor existed before entering, __exit__ must
+        # delete the instance attribute (not leave a stale partial behind).
+        # Temporarily remove any pre-existing instance cursor (e.g. set by
+        # Django Debug Toolbar) so we can test the class-method restore path.
+        conn = connections['default']
+        preexisting = conn.__dict__.pop('cursor', None)
+        preexisting_chunked = conn.__dict__.pop('chunked_cursor', None)
+        try:
+            self.assertNotIn('cursor', conn.__dict__)
+
+            with SQLQueryRecorder(databases=['default']):
+                self.assertIn('cursor', conn.__dict__)
+
+            # The instance attribute must be gone; the class method is accessible again
+            self.assertNotIn('cursor', conn.__dict__)
+            self.assertIsInstance(conn.cursor(), CursorWrapper)
+        finally:
+            if preexisting is not None:
+                conn.cursor = preexisting
+            if preexisting_chunked is not None:
+                conn.chunked_cursor = preexisting_chunked


### PR DESCRIPTION
`__exit__` used `del connection.cursor` unconditionally, which discards any pre-existing instance-level cursor (e.g. Django's `_DatabaseFailure` wrapper set by `SimpleTestCase._add_databases_failures`). On teardown Django then called `.wrapped` on what it expected to be its wrapper but found a plain class method → AttributeError.

Fix: restore the saved value with `setattr` when it was an instance attribute; only `delattr` when the original was the class-level method. Extract `_restore_cursor` helper to avoid repeating the logic for `cursor` and `chunked_cursor`.