### PR TITLE
Skip "uv audit" in CI pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ install:  ## Install via "uv" (Used system installed "uv" tool, e.g.: "pipx inst
 .PHONY: update-requirements
 update-requirements:  ## Update requirements
 	uv lock --upgrade
-	uv sync
+	uv sync --all-extras
+	uv audit
 	$(MAKE) pip-audit
 
 .PHONY: lint

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,8 @@
 # https://github.com/wntrblm/nox/
 # Documentation: https://nox.thea.codes/
 #
+import os
+
 import nox
 from nox.sessions import Session
 
@@ -31,10 +33,11 @@ def tests(session: Session, django: str):
     )
 
     # uv audit it fast, so run it every time:
-    session.run(
-        'uv',
-        'audit',
-        env={'UV_PROJECT_ENVIRONMENT': session.virtualenv.location},
-    )
+    if 'CI' not in os.environ:  # ...but skip it in CI
+        session.run(
+            'uv',
+            'audit',
+            env={'UV_PROJECT_ENVIRONMENT': session.virtualenv.location},
+        )
 
     session.run('python', '-m', 'coverage', 'run', '--context', f'py{session.python}-django{django}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ exclude-newer = "1 week"
 [tool.uv.exclude-newer-package]
 # Exclude packages temporarily from the "exclude-newer" rule to fix known issues or current CVEs
 cryptography = "2026-07-07T12:00:00Z"
+django = "2026-07-10T12:00:00Z"
 
 
 [project.urls]


### PR DESCRIPTION
This is a library and not a project, so we didn't have a fixed "uv.lock" file that should be used on CI pipeline. Don't block the pipeline because if new CVEs. The project maintainers need to deal with this type of problem.

Add "django" to "tool.uv.exclude-newer-package" to get 6.0.7 with fixed CVEs locally. Also install all extras via "make update-requirements" and also call "uv audit" because it's fast. Maybe we should remove "pip-audit" in the long run?